### PR TITLE
ApiDoc Automation script created & mock portfolio data generator refectored.

### DIFF
--- a/creditrisk_poc/api_doc/ApiDoc.jsonld
+++ b/creditrisk_poc/api_doc/ApiDoc.jsonld
@@ -65,9 +65,118 @@
     "possibleStatus": [],
     "supportedClass": [
         {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+            "@type": "hydra:Class",
+            "description": "",
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/FindAction",
+                    "expects": null,
+                    "expectsHeader": [],
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@type": "Status",
+                            "description": "CounterParty class returned.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                    "returnsHeader": [],
+                    "title": "CounterPartyGET"
+                },
+                {
+                    "@type": "http://schema.org/AddAction",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                    "expectsHeader": [],
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@type": "Status",
+                            "description": "CounterParty class Added.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": null,
+                    "returnsHeader": [],
+                    "title": "CounterPartyPUT"
+                },
+                {
+                    "@type": "http://schema.org/UpdateAction",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@type": "Status",
+                            "description": "CounterParty class updated.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": null,
+                    "returnsHeader": [
+                        "Content-Type",
+                        "Content-Length"
+                    ],
+                    "title": "CounterPartyPOST"
+                },
+                {
+                    "@type": "http://schema.org/DeleteAction",
+                    "expects": null,
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@type": "Status",
+                            "description": "CounterParty class Deleted.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": null,
+                    "returnsHeader": [],
+                    "title": "CounterPartyDELETE"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_legal_entity_identifier",
+                    "readable": true,
+                    "required": true,
+                    "title": "LegalEntityIdentifier",
+                    "writeable": true
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_total_assets",
+                    "readable": true,
+                    "required": true,
+                    "title": "TotalAssets",
+                    "writeable": true
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_date_of_incorporation",
+                    "readable": true,
+                    "required": true,
+                    "title": "DateOfIncorporation",
+                    "writeable": true
+                }
+            ],
+            "title": "CounterParty"
+        },
+        {
             "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
             "@type": "hydra:Class",
-            "description": "This class contains the information regarding Loan",
+            "description": "",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/FindAction",
@@ -85,7 +194,25 @@
                     ],
                     "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
                     "returnsHeader": [],
-                    "title": "GetLoan"
+                    "title": "LoanGET"
+                },
+                {
+                    "@type": "http://schema.org/AddAction",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
+                    "expectsHeader": [],
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@type": "Status",
+                            "description": "Loan class Added.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": null,
+                    "returnsHeader": [],
+                    "title": "LoanPUT"
                 },
                 {
                     "@type": "http://schema.org/UpdateAction",
@@ -106,25 +233,7 @@
                         "Content-Type",
                         "Content-Length"
                     ],
-                    "title": "UpdateLoan"
-                },
-                {
-                    "@type": "http://schema.org/AddAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
-                    "expectsHeader": [],
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Loan class updated.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "AddLoan"
+                    "title": "LoanPOST"
                 },
                 {
                     "@type": "http://schema.org/DeleteAction",
@@ -135,20 +244,28 @@
                         {
                             "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                             "@type": "Status",
-                            "description": "Loan class deleted.",
+                            "description": "Loan class Deleted.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
                     "returns": null,
                     "returnsHeader": [],
-                    "title": "DeleteLoan"
+                    "title": "LoanDELETE"
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "property": "NPL:TotalBalance",
+                    "property": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                    "readable": true,
+                    "required": true,
+                    "title": "CounterpartyId",
+                    "writeable": true
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_total_balance",
                     "readable": true,
                     "required": true,
                     "title": "TotalBalance",
@@ -156,133 +273,19 @@
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "NPL:ChannelOfOrigination",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_channel_of_origination",
                     "readable": true,
                     "required": true,
                     "title": "ChannelOfOrigination",
-                    "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                    "readable": true,
-                    "required": true,
-                    "title": "CounterpartyId",
                     "writeable": true
                 }
             ],
             "title": "Loan"
         },
         {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-            "@type": "hydra:Class",
-            "description": "This class contains the information regarding Loan",
-            "supportedOperation": [
-                {
-                    "@type": "http://schema.org/FindAction",
-                    "expects": null,
-                    "expectsHeader": [],
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Borrower class returned.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                    "returnsHeader": [],
-                    "title": "GetBorrower"
-                },
-                {
-                    "@type": "http://schema.org/UpdateAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                    "expectsHeader": [],
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Borrower class updated.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "UpdateBorrower"
-                },
-                {
-                    "@type": "http://schema.org/AddAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                    "expectsHeader": [],
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Borrower class updated.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "AddBorrower"
-                },
-                {
-                    "@type": "http://schema.org/DeleteAction",
-                    "expects": null,
-                    "expectsHeader": [],
-                    "method": "DELETE",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Borrower class deleted.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "DeleteBorrower"
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "property": "NPL:LegalEntityIdentifier",
-                    "readable": true,
-                    "required": true,
-                    "title": "LegalEntityIdentifier",
-                    "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "NPL:TotalAssets",
-                    "readable": true,
-                    "required": true,
-                    "title": "TotalAssets",
-                    "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "NPL:DateOfIncorporation",
-                    "readable": true,
-                    "required": true,
-                    "title": "DateOfIncorporation",
-                    "writeable": true
-                }
-            ],
-            "title": "Borrower"
-        },
-        {
             "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
             "@type": "hydra:Class",
-            "description": "This class contains the information regarding Collateral",
+            "description": "",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/FindAction",
@@ -300,7 +303,7 @@
                     ],
                     "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
                     "returnsHeader": [],
-                    "title": "GetCollateral"
+                    "title": "CollateralGET"
                 },
                 {
                     "@type": "http://schema.org/AddAction",
@@ -311,14 +314,14 @@
                         {
                             "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                             "@type": "Status",
-                            "description": "Collateral class updated.",
+                            "description": "Collateral class Added.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
                     "returns": null,
                     "returnsHeader": [],
-                    "title": "AddCollateral"
+                    "title": "CollateralPUT"
                 },
                 {
                     "@type": "http://schema.org/UpdateAction",
@@ -335,8 +338,11 @@
                         }
                     ],
                     "returns": null,
-                    "returnsHeader": [],
-                    "title": "UpdateCollateral"
+                    "returnsHeader": [
+                        "Content-Type",
+                        "Content-Length"
+                    ],
+                    "title": "CollateralPOST"
                 },
                 {
                     "@type": "http://schema.org/DeleteAction",
@@ -347,20 +353,20 @@
                         {
                             "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                             "@type": "Status",
-                            "description": "Collateral class updated.",
+                            "description": "Collateral class Deleted.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
                     "returns": null,
                     "returnsHeader": [],
-                    "title": "DeleteCollateral"
+                    "title": "CollateralDELETE"
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "property": "NPL:CollateralType",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_collateral_type",
                     "readable": true,
                     "required": true,
                     "title": "CollateralType",
@@ -368,7 +374,7 @@
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "NPL:LatestValuationAmount",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_latest_valuation_amount",
                     "readable": true,
                     "required": true,
                     "title": "LatestValuationAmount",
@@ -411,88 +417,88 @@
             "title": "Collection"
         },
         {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Borrowers",
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty_collection",
             "@type": "Collection",
             "description": "Collection for Borrower class",
             "manages": {
-                "object": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                "object": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                 "property": "rdf:type"
             },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "_:Borrowers_retrieve",
+                    "@id": "_:CounterParty_collection_retrieve",
                     "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all the members of Borrowers",
+                    "description": "Retrieves all the members of CounterParty_collection",
                     "expects": null,
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "returnsHeader": []
                 },
                 {
-                    "@id": "_:Borrowers_create",
+                    "@id": "_:CounterParty_collection_create",
                     "@type": "http://schema.org/AddAction",
-                    "description": "Create new member in Borrowers",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "description": "Create new member in CounterParty_collection",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
                             "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                             "@type": "Status",
-                            "description": "A new member in Borrowers created",
+                            "description": "A new member in CounterParty_collection created",
                             "statusCode": 201,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "returnsHeader": []
                 },
                 {
-                    "@id": "_:Borrowers_update",
+                    "@id": "_:CounterParty_collection_update",
                     "@type": "http://schema.org/UpdateAction",
-                    "description": "Update member of  Borrowers ",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "description": "Update member of  CounterParty_collection ",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
                             "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                             "@type": "Status",
-                            "description": "If the entity was updatedfrom Borrowers.",
+                            "description": "If the entity was updatedfrom CounterParty_collection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "returnsHeader": []
                 },
                 {
-                    "@id": "_:Borrowers_delete",
+                    "@id": "_:CounterParty_collection_delete",
                     "@type": "http://schema.org/DeleteAction",
-                    "description": "Delete member of Borrowers ",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "description": "Delete member of CounterParty_collection ",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "expectsHeader": [],
                     "method": "DELETE",
                     "possibleStatus": [
                         {
                             "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                             "@type": "Status",
-                            "description": "If entity was deletedsuccessfully from Borrowers.",
+                            "description": "If entity was deletedsuccessfully from CounterParty_collection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "returnsHeader": []
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "description": "The members of Borrowers",
+                    "description": "The members of CounterParty_collection",
                     "property": "http://www.w3.org/ns/hydra/core#member",
                     "readable": true,
                     "required": false,
@@ -500,7 +506,7 @@
                     "writeable": true
                 }
             ],
-            "title": "Borrowers"
+            "title": "CounterParty_collection"
         },
         {
             "@id": "http://localhost:8080/creditrisk_api#EntryPoint",
@@ -521,23 +527,123 @@
             ],
             "supportedProperty": [
                 {
+                    "hydra:description": "The CounterParty Class",
+                    "hydra:title": "counterparty",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CounterParty",
+                        "@type": "hydra:Link",
+                        "description": "",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "CounterParty",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                        "supportedOperation": [
+                            {
+                                "@id": "counterpartyget",
+                                "@type": "http://schema.org/FindAction",
+                                "description": null,
+                                "expects": null,
+                                "expectsHeader": [],
+                                "label": "CounterPartyGET",
+                                "method": "GET",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@type": "Status",
+                                        "description": "CounterParty class returned.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "counterpartyput",
+                                "@type": "http://schema.org/AddAction",
+                                "description": null,
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                                "expectsHeader": [],
+                                "label": "CounterPartyPUT",
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@type": "Status",
+                                        "description": "CounterParty class Added.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": null,
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "counterpartypost",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": null,
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                                "expectsHeader": [],
+                                "label": "CounterPartyPOST",
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@type": "Status",
+                                        "description": "CounterParty class updated.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": null,
+                                "returnsHeader": [
+                                    "Content-Type",
+                                    "Content-Length"
+                                ]
+                            },
+                            {
+                                "@id": "counterpartydelete",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": null,
+                                "expects": null,
+                                "expectsHeader": [],
+                                "label": "CounterPartyDELETE",
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@type": "Status",
+                                        "description": "CounterParty class Deleted.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": null,
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
                     "hydra:description": "The Loan Class",
                     "hydra:title": "loan",
                     "property": {
                         "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Loan",
                         "@type": "hydra:Link",
-                        "description": "This class contains the information regarding Loan",
+                        "description": "",
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
                         "label": "Loan",
                         "range": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
                         "supportedOperation": [
                             {
-                                "@id": "getloan",
+                                "@id": "loanget",
                                 "@type": "http://schema.org/FindAction",
                                 "description": null,
                                 "expects": null,
                                 "expectsHeader": [],
-                                "label": "GetLoan",
+                                "label": "LoanGET",
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
@@ -552,12 +658,32 @@
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "updateloan",
+                                "@id": "loanput",
+                                "@type": "http://schema.org/AddAction",
+                                "description": null,
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
+                                "expectsHeader": [],
+                                "label": "LoanPUT",
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@type": "Status",
+                                        "description": "Loan class Added.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": null,
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "loanpost",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": null,
                                 "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
                                 "expectsHeader": [],
-                                "label": "UpdateLoan",
+                                "label": "LoanPOST",
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
@@ -575,135 +701,18 @@
                                 ]
                             },
                             {
-                                "@id": "addloan",
-                                "@type": "http://schema.org/AddAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
-                                "expectsHeader": [],
-                                "label": "AddLoan",
-                                "method": "PUT",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Loan class updated.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "deleteloan",
+                                "@id": "loandelete",
                                 "@type": "http://schema.org/DeleteAction",
                                 "description": null,
                                 "expects": null,
                                 "expectsHeader": [],
-                                "label": "DeleteLoan",
+                                "label": "LoanDELETE",
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
                                         "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                                         "@type": "Status",
-                                        "description": "Loan class deleted.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            }
-                        ]
-                    },
-                    "readable": true,
-                    "required": null,
-                    "writeable": false
-                },
-                {
-                    "hydra:description": "The Borrower Class",
-                    "hydra:title": "borrower",
-                    "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Borrower",
-                        "@type": "hydra:Link",
-                        "description": "This class contains the information regarding Loan",
-                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "Borrower",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                        "supportedOperation": [
-                            {
-                                "@id": "getborrower",
-                                "@type": "http://schema.org/FindAction",
-                                "description": null,
-                                "expects": null,
-                                "expectsHeader": [],
-                                "label": "GetBorrower",
-                                "method": "GET",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Borrower class returned.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "updateborrower",
-                                "@type": "http://schema.org/UpdateAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                                "expectsHeader": [],
-                                "label": "UpdateBorrower",
-                                "method": "POST",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Borrower class updated.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "addborrower",
-                                "@type": "http://schema.org/AddAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                                "expectsHeader": [],
-                                "label": "AddBorrower",
-                                "method": "PUT",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Borrower class updated.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "deleteborrower",
-                                "@type": "http://schema.org/DeleteAction",
-                                "description": null,
-                                "expects": null,
-                                "expectsHeader": [],
-                                "label": "DeleteBorrower",
-                                "method": "DELETE",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Borrower class deleted.",
+                                        "description": "Loan class Deleted.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
@@ -723,18 +732,18 @@
                     "property": {
                         "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Collateral",
                         "@type": "hydra:Link",
-                        "description": "This class contains the information regarding Collateral",
+                        "description": "",
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
                         "label": "Collateral",
                         "range": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
                         "supportedOperation": [
                             {
-                                "@id": "getcollateral",
+                                "@id": "collateralget",
                                 "@type": "http://schema.org/FindAction",
                                 "description": null,
                                 "expects": null,
                                 "expectsHeader": [],
-                                "label": "GetCollateral",
+                                "label": "CollateralGET",
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
@@ -749,18 +758,18 @@
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "addcollateral",
+                                "@id": "collateralput",
                                 "@type": "http://schema.org/AddAction",
                                 "description": null,
                                 "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
                                 "expectsHeader": [],
-                                "label": "AddCollateral",
+                                "label": "CollateralPUT",
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
                                         "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                                         "@type": "Status",
-                                        "description": "Collateral class updated.",
+                                        "description": "Collateral class Added.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
@@ -769,12 +778,12 @@
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "updatecollateral",
+                                "@id": "collateralpost",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": null,
                                 "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
                                 "expectsHeader": [],
-                                "label": "UpdateCollateral",
+                                "label": "CollateralPOST",
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
@@ -786,21 +795,24 @@
                                     }
                                 ],
                                 "returns": null,
-                                "returnsHeader": []
+                                "returnsHeader": [
+                                    "Content-Type",
+                                    "Content-Length"
+                                ]
                             },
                             {
-                                "@id": "deletecollateral",
+                                "@id": "collateraldelete",
                                 "@type": "http://schema.org/DeleteAction",
                                 "description": null,
                                 "expects": null,
                                 "expectsHeader": [],
-                                "label": "DeleteCollateral",
+                                "label": "CollateralDELETE",
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
                                         "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                                         "@type": "Status",
-                                        "description": "Collateral class updated.",
+                                        "description": "Collateral class Deleted.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
@@ -815,86 +827,86 @@
                     "writeable": false
                 },
                 {
-                    "hydra:description": "The Borrowers collection",
-                    "hydra:title": "borrowers",
+                    "hydra:description": "The CounterParty_collection collection",
+                    "hydra:title": "counterparty_collection",
                     "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Borrowers",
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CounterParty_collection",
                         "@type": "hydra:Link",
-                        "description": "The Borrowers collection",
+                        "description": "The CounterParty_collection collection",
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "Borrowers",
+                        "label": "CounterParty_collection",
                         "manages": {
-                            "object": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                            "object": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                             "property": "rdf:type"
                         },
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Borrowers",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty_collection",
                         "supportedOperation": [
                             {
-                                "@id": "_:borrowers_retrieve",
+                                "@id": "_:counterparty_collection_retrieve",
                                 "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all the members of Borrowers",
+                                "description": "Retrieves all the members of CounterParty_collection",
                                 "expects": null,
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "_:borrowers_create",
+                                "@id": "_:counterparty_collection_create",
                                 "@type": "http://schema.org/AddAction",
-                                "description": "Create new member in Borrowers",
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "description": "Create new member in CounterParty_collection",
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
                                         "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                                         "@type": "Status",
-                                        "description": "A new member in Borrowers created",
+                                        "description": "A new member in CounterParty_collection created",
                                         "statusCode": 201,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "_:borrowers_update",
+                                "@id": "_:counterparty_collection_update",
                                 "@type": "http://schema.org/UpdateAction",
-                                "description": "Update member of  Borrowers ",
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "description": "Update member of  CounterParty_collection ",
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "expectsHeader": [],
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
                                         "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                                         "@type": "Status",
-                                        "description": "If the entity was updatedfrom Borrowers.",
+                                        "description": "If the entity was updatedfrom CounterParty_collection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "_:borrowers_delete",
+                                "@id": "_:counterparty_collection_delete",
                                 "@type": "http://schema.org/DeleteAction",
-                                "description": "Delete member of Borrowers ",
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "description": "Delete member of CounterParty_collection ",
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "expectsHeader": [],
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
                                         "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                                         "@type": "Status",
-                                        "description": "If entity was deletedsuccessfully from Borrowers.",
+                                        "description": "If entity was deletedsuccessfully from CounterParty_collection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "returnsHeader": []
                             }
                         ]

--- a/creditrisk_poc/api_doc/NPLVocab_parser.py
+++ b/creditrisk_poc/api_doc/NPLVocab_parser.py
@@ -96,13 +96,6 @@ def add_operations_to_class(hydra_classes: list, class_name: str, operations: li
     return hydra_operations
 
 
-if __name__ == '__main__':
-    #npl_vocab = get_npl_vocab()
-    #classes = get_all_classes(npl_vocab)
-    #hydra_classes = create_hydra_classes(classes)
-
-
-
 
 
 

--- a/creditrisk_poc/api_doc/NPLVocab_parser.py
+++ b/creditrisk_poc/api_doc/NPLVocab_parser.py
@@ -1,0 +1,109 @@
+import json
+import os
+from hydra_python_core.doc_writer import HydraClass, HydraClassProp, HydraClassOp, HydraStatus
+
+
+def get_npl_vocab() -> dict:
+    vocab_file_path = os.path.join(os.path.dirname(os.getcwd()), "npl_vocab/NonPerformingLoan.jsonld")
+    npl_vocab_file = open(vocab_file_path)
+    npl_vocab = json.load(npl_vocab_file)
+    return npl_vocab
+
+
+def get_all_classes(vocab: dict) -> list:
+    """
+    Get all the classes from the given Vocabulary.
+    """
+    classes = list()
+    defines = vocab['defines']
+    for obj in defines:
+        if obj['@type'] == 'rdfs:Class':
+            classes.append(obj)
+    return classes
+
+
+def create_hydra_classes(vocab_classes: list) -> list:
+    """
+    Create hydra classes from list of vocab classes.
+    """
+    hydra_classes = list()
+    for class_ in vocab_classes:
+        hydra_class = HydraClass(class_['rdfs:label'], class_['rdfs:comment'], endpoint=True)
+        hydra_classes.append(hydra_class)
+    return hydra_classes
+
+
+def get_class_properties(class_ : str, vocab : dict) -> list:
+    """
+    Return all the properties of the given class.
+    """
+    properties = list()
+    defines = vocab['defines']
+    for obj in defines:
+        if obj.get('propertyOf'):
+            propertyof = obj['propertyOf']['@id'].split('#')[1]
+            if propertyof == class_ or obj['@type'] == 'owl:DataProperty' and obj['@type'] == 'owl:ObjectProperty':
+                properties.append(obj)
+    return properties
+
+
+def create_hydra_properties(property_: dict, hydra_classes: dict) -> HydraClassProp:
+    if property_.get('propertyOn') and isinstance(property_['propertyOn'], dict):
+        property_on_class = property_.get("propertyOn")['@id'].split('#')[1]
+        property_uri = hydra_classes[property_on_class].id_
+    else:
+        property_uri = property_['@id']
+    hydra_property = HydraClassProp(property_uri, property_['rdfs:label'],
+                                    required=True, read=True, write=True)
+    return hydra_property
+
+
+def get_class_id(class_name: str, hydra_classes: list):
+    """
+    Returns the class id of given class.
+    """
+    for class_ in hydra_classes:
+        if class_.title == class_name:
+            return class_.id_
+
+
+def add_operations_to_class(hydra_classes: list, class_name: str, operations: list) -> list:
+    """
+    Return list of hydra properties of given class.
+    """
+    hydra_operations = []
+    class_id = get_class_id(class_name, hydra_classes)
+    if class_id:
+        for operation in operations:
+            if operation == "GET":
+                get_operation_status = [HydraStatus(code=200, desc=class_name + " class returned.")]
+                op = HydraClassOp(class_name + operation, operation, None, class_id, [], [], get_operation_status)
+                hydra_operations.append(op)
+            if operation == "PUT":
+                put_operation_status = [HydraStatus(code=200, desc=class_name + " class Added.")]
+                op = HydraClassOp(class_name + operation, operation, class_id, None, [], [], put_operation_status)
+                hydra_operations.append(op)
+            if operation == "POST":
+                put_operation_status = [HydraStatus(code=200, desc=class_name + " class updated.")]
+                op = HydraClassOp(class_name + operation, operation, class_id, None, [], ["Content-Type", "Content-Length"],
+                                  put_operation_status)
+                hydra_operations.append(op)
+            if operation == "DELETE":
+                put_operation_status = [HydraStatus(code=200, desc=class_name + " class Deleted.")]
+                op = HydraClassOp(class_name + operation, operation, None, None, [], [],
+                                  put_operation_status)
+                hydra_operations.append(op)
+    return hydra_operations
+
+
+if __name__ == '__main__':
+    #npl_vocab = get_npl_vocab()
+    #classes = get_all_classes(npl_vocab)
+    #hydra_classes = create_hydra_classes(classes)
+
+
+
+
+
+
+

--- a/creditrisk_poc/api_doc/NPLVocab_parser.py
+++ b/creditrisk_poc/api_doc/NPLVocab_parser.py
@@ -1,10 +1,12 @@
 import json
-import os
+from os.path import abspath, dirname
 from hydra_python_core.doc_writer import HydraClass, HydraClassProp, HydraClassOp, HydraStatus
+from pathlib import Path
 
 
 def get_npl_vocab() -> dict:
-    vocab_file_path = os.path.join(os.path.dirname(os.getcwd()), "npl_vocab/NonPerformingLoan.jsonld")
+    cwd_path = Path(dirname(dirname(abspath(__file__))))
+    vocab_file_path = cwd_path / "npl_vocab" / "NonPerformingLoan.jsonld"
     npl_vocab_file = open(vocab_file_path)
     npl_vocab = json.load(npl_vocab_file)
     return npl_vocab

--- a/creditrisk_poc/api_doc/api_docwriter.py
+++ b/creditrisk_poc/api_doc/api_docwriter.py
@@ -3,11 +3,11 @@ import json
 from hydra_python_core.doc_writer import (HydraDoc, HydraClass,
                                           HydraClassProp, HydraClassOp, HydraStatus, HydraCollection)
 import logging
+import NPLVocab_parser as parser
 
 logging.basicConfig(filename="docwriter_log.log", format='%(asctime)s %(message)s', filemode='a')
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
-
 
 API_NAME = "creditrisk_api"
 BASE_URL = "http://localhost:8080/"
@@ -24,312 +24,52 @@ api_doc = HydraDoc(API_NAME,
 api_doc.add_to_context("NPL",
                        "https://raw.githubusercontent.com/Purvanshsingh/creditrisk-poc/main/NonPerformingLoan.jsonld#")
 
-# Creating borrower class
-borrower_class_title = "Borrower"
-borrower_class_description = "This class contains the information regarding Loan"
-borrower_class = HydraClass(borrower_class_title, borrower_class_description, endpoint=True)
-# Adding properties to Borrower class
-borrower_property1_uri = "NPL:LegalEntityIdentifier"
-borrower_property1_title = "LegalEntityIdentifier"
-LegalEntityIdentifier_prop = HydraClassProp(borrower_property1_uri, borrower_property1_title,
-                                            required=True, read=True, write=True)
-borrower_property2_uri = "NPL:TotalAssets"
-borrower_property2_title = "TotalAssets"
-TotalAssets_prop = HydraClassProp(borrower_property2_uri, borrower_property2_title,
-                                  required=True, read=True, write=True)
-borrower_property3_uri = "NPL:DateOfIncorporation"
-borrower_property3_title = "DateOfIncorporation"
-DateOfIncorporation_prop = HydraClassProp(borrower_property3_uri, borrower_property3_title,
-                                          required=True, read=True, write=True)
+npl_vocab = parser.get_npl_vocab()
+classes = parser.get_all_classes(npl_vocab)
+hydra_classes = parser.create_hydra_classes(classes)
+classes = {class_.title: class_ for class_ in hydra_classes}
+
+loan_foriegnkey_uri = classes['CounterParty'].id_
+loan_foriegnkey_title = "CounterpartyId"
+CounterpartyId_prop = HydraClassProp(loan_foriegnkey_uri, loan_foriegnkey_title,
+                                     required=True, read=True, write=True)
+classes['Loan'].add_supported_prop(CounterpartyId_prop)
+
+Loan_operations = parser.add_operations_to_class(hydra_classes, "Loan", ["GET", "PUT", "POST", "DELETE"])
+CounterParty_operations = parser.add_operations_to_class(hydra_classes, "CounterParty",
+                                                         ["GET", "PUT", "POST", "DELETE"])
+Collateral_operations = parser.add_operations_to_class(hydra_classes, "Collateral", ["GET", "PUT", "POST", "DELETE"])
+
+for class_ in hydra_classes:
+    class_name = class_.title
+    class_properties = parser.get_class_properties(class_name, npl_vocab)
+    for property_ in class_properties:
+        prop = parser.create_hydra_properties(property_, classes)
+        class_.add_supported_prop(prop)
+    class_operations = eval(class_name + "_operations")
+    for operation in class_operations:
+        class_.add_supported_op(operation)
+    api_doc.add_supported_class(class_)
+
+
+
+
 # Creating Borrower Collection
-borrower_collection_name = "Borrowers"
-borrower_collection_title = "Borrower class collection"
-borrower_collection_description = "Collection for Borrower class"
-borrower_collection_managed_by = {
+counterparty_collection_name = "CounterParty_collection"
+counterparty_collection_title = "CounterParty class collection"
+counterparty_collection_description = "Collection for Borrower class"
+counterparty_collection_managed_by = {
     "property": "rdf:type",
-    "object": borrower_class.id_,
+    "object": parser.get_class_id("CounterParty", hydra_classes),
 }
-borrower_collection = HydraCollection(collection_name=borrower_collection_name,
-                                      collection_description=borrower_collection_description,
-                                      manages=borrower_collection_managed_by,
-                                      get=True,
-                                      post=True,
-                                      put=True,
-                                      delete=True)
-# Creating Loan class
-loan_class_title = "Loan"
-loan_class_description = "This class contains the information regarding Loan"
-loan_class = HydraClass(loan_class_title, loan_class_description, endpoint=True)
-# Adding properties to load class
-loan_property1_uri = "NPL:TotalBalance"
-loan_property1_title = "TotalBalance"
-Total_balance_prop = HydraClassProp(loan_property1_uri, loan_property1_title,
-                                    required=True, read=True, write=True)
-loan_property2_uri = "NPL:ChannelOfOrigination"
-loan_property2_title = "ChannelOfOrigination"
-Origination_prop = HydraClassProp(loan_property2_uri, loan_property2_title,
-                                  required=True, read=True, write=True)
-loan_property3_uri = borrower_class.id_
-loan_property3_title = "CounterpartyId"
-CounterpartyId_prop = HydraClassProp(loan_property3_uri, loan_property3_title,
-                                     required=True, read=True, write=True)
-# Creating Collateral class
-collateral_class_title = "Collateral"
-collateral_class_description = "This class contains the information regarding Collateral"
-collateral_class = HydraClass(collateral_class_title, collateral_class_description, endpoint=True)
-# Adding properties to Collateral class
-collateral_property1_uri = "NPL:CollateralType"
-collateral_property1_title = "CollateralType"
-CollateralType_prop = HydraClassProp(collateral_property1_uri, collateral_property1_title,
-                                     required=True, read=True, write=True)
-collateral_property2_uri = "NPL:LatestValuationAmount"
-collateral_property2_title = "LatestValuationAmount"
-LatestValuationAmount_prop = HydraClassProp(collateral_property2_uri, collateral_property2_title,
-                                            required=True, read=True, write=True)
-collateral_property3_uri = loan_class.id_
-collateral_property3_title = "ConcernLoan"
-ConcernLoan_prop = HydraClassProp(collateral_property3_uri, collateral_property3_title,
-                                  required=True, read=True, write=True)
-
-# Loan class operations
-update_loan_operation = "UpdateLoan"
-update_loan_operation_method = "POST"
-update_loan_operation_expects = loan_class.id_
-update_loan_operation_returns = None
-update_loan_operation_returns_header = ["Content-Type", "Content-Length"]
-update_loan_operation_expects_header = []
-# status code
-update_loan_operation_status = [HydraStatus(code=200, desc="Loan class updated.")]
-
-add_loan_operation = "AddLoan"
-add_loan_operation_method = "PUT"
-add_loan_operation_expects = loan_class.id_
-add_loan_operation_returns = None
-add_loan_operation_returns_header = []
-add_loan_operation_expects_header = []
-# status code
-add_loan_operation_status = [HydraStatus(code=200, desc="Loan class updated.")]
-
-get_loan_operation = "GetLoan"
-get_loan_operation_method = "GET"
-get_loan_operation_expects = None
-get_loan_operation_returns = loan_class.id_
-get_loan_operation_returns_header = []
-get_loan_operation_expects_header = []
-# Status code
-get_loan_operation_status = [HydraStatus(code=200, desc="Loan class returned.")]
-
-delete_loan_operation = "DeleteLoan"
-delete_loan_operation_method = "DELETE"
-delete_loan_operation_expects = None
-delete_loan_operation_returns = None
-delete_loan_operation_returns_header = []
-delete_loan_operation_expects_header = []
-# Status code
-delete_loan_operation_status = [HydraStatus(code=200, desc="Loan class deleted.")]
-
-loan_post = HydraClassOp(update_loan_operation,
-                         update_loan_operation_method,
-                         update_loan_operation_expects,
-                         update_loan_operation_returns,
-                         update_loan_operation_expects_header,
-                         update_loan_operation_returns_header,
-                         update_loan_operation_status)
-
-loan_add = HydraClassOp(add_loan_operation,
-                        add_loan_operation_method,
-                        add_loan_operation_expects,
-                        add_loan_operation_returns,
-                        add_loan_operation_expects_header,
-                        add_loan_operation_returns_header,
-                        add_loan_operation_status)
-
-loan_get = HydraClassOp(get_loan_operation,
-                        get_loan_operation_method,
-                        get_loan_operation_expects,
-                        get_loan_operation_returns,
-                        get_loan_operation_expects_header,
-                        get_loan_operation_returns_header,
-                        get_loan_operation_status)
-
-loan_delete = HydraClassOp(delete_loan_operation,
-                           delete_loan_operation_method,
-                           delete_loan_operation_expects,
-                           delete_loan_operation_returns,
-                           delete_loan_operation_expects_header,
-                           delete_loan_operation_returns_header,
-                           delete_loan_operation_status)
-# operations for borrower class
-update_borrower_operation = "UpdateBorrower"
-update_borrower_operation_method = "POST"
-update_borrower_operation_expects = borrower_class.id_
-update_borrower_operation_returns = None
-update_borrower_operation_returns_header = []
-update_borrower_operation_expects_header = []
-# status code
-update_borrower_operation_status = [HydraStatus(code=200, desc="Borrower class updated.")]
-
-add_borrower_operation = "AddBorrower"
-add_borrower_operation_method = "PUT"
-add_borrower_operation_expects = borrower_class.id_
-add_borrower_operation_returns = None
-add_borrower_operation_returns_header = []
-add_borrower_operation_expects_header = []
-# status code
-add_borrower_operation_status = [HydraStatus(code=200, desc="Borrower class updated.")]
-
-get_borrower_operation = "GetBorrower"
-get_borrower_operation_method = "GET"
-get_borrower_operation_expects = None
-get_borrower_operation_returns = borrower_class.id_
-get_borrower_operation_returns_header = []
-get_borrower_operation_expects_header = []
-# Status code
-get_borrower_operation_status = [HydraStatus(code=200, desc="Borrower class returned.")]
-
-delete_borrower_operation = "DeleteBorrower"
-delete_borrower_operation_method = "DELETE"
-delete_borrower_operation_expects = None
-delete_borrower_operation_returns = None
-delete_borrower_operation_returns_header = []
-delete_borrower_operation_expects_header = []
-# Status code
-delete_borrower_operation_status = [HydraStatus(code=200, desc="Borrower class deleted.")]
-
-borrower_post = HydraClassOp(update_borrower_operation,
-                             update_borrower_operation_method,
-                             update_borrower_operation_expects,
-                             update_borrower_operation_returns,
-                             update_borrower_operation_expects_header,
-                             update_borrower_operation_returns_header,
-                             update_borrower_operation_status)
-
-borrower_add = HydraClassOp(add_borrower_operation,
-                            add_borrower_operation_method,
-                            add_borrower_operation_expects,
-                            add_borrower_operation_returns,
-                            add_borrower_operation_expects_header,
-                            add_borrower_operation_returns_header,
-                            add_borrower_operation_status)
-
-borrower_get = HydraClassOp(get_borrower_operation,
-                            get_borrower_operation_method,
-                            get_borrower_operation_expects,
-                            get_borrower_operation_returns,
-                            get_borrower_operation_expects_header,
-                            get_borrower_operation_returns_header,
-                            get_borrower_operation_status)
-
-borrower_delete = HydraClassOp(delete_borrower_operation,
-                               delete_borrower_operation_method,
-                               delete_borrower_operation_expects,
-                               delete_borrower_operation_returns,
-                               delete_borrower_operation_expects_header,
-                               delete_borrower_operation_returns_header,
-                               delete_borrower_operation_status)
-# operations for Collateral class
-update_collateral_operation = "UpdateCollateral"
-update_collateral_operation_method = "POST"
-update_collateral_operation_expects = collateral_class.id_
-update_collateral_operation_returns = None
-update_collateral_operation_returns_header = []
-update_collateral_operation_expects_header = []
-# status code
-update_collateral_operation_status = [HydraStatus(code=200, desc="Collateral class updated.")]
-
-add_collateral_operation = "AddCollateral"
-add_collateral_operation_method = "PUT"
-add_collateral_operation_expects = collateral_class.id_
-add_collateral_operation_returns = None
-add_collateral_operation_returns_header = []
-add_collateral_operation_expects_header = []
-# status code
-add_collateral_operation_status = [HydraStatus(code=200, desc="Collateral class updated.")]
-
-get_collateral_operation = "GetCollateral"
-get_collateral_operation_method = "GET"
-get_collateral_operation_expects = None
-get_collateral_operation_returns = collateral_class.id_
-get_collateral_operation_returns_header = []
-get_collateral_operation_expects_header = []
-# Status code
-get_collateral_operation_status = [HydraStatus(code=200, desc="Collateral class returned.")]
-
-delete_collateral_operation = "DeleteCollateral"
-delete_collateral_operation_method = "DELETE"
-delete_collateral_operation_expects = None
-delete_collateral_operation_returns = None
-delete_collateral_operation_returns_header = []
-delete_collateral_operation_expects_header = []
-# Status code
-delete_collateral_operation_status = [HydraStatus(code=200, desc="Collateral class deleted.")]
-
-collateral_post = HydraClassOp(update_collateral_operation,
-                               update_collateral_operation_method,
-                               update_collateral_operation_expects,
-                               update_collateral_operation_returns,
-                               update_collateral_operation_expects_header,
-                               update_collateral_operation_returns_header,
-                               update_collateral_operation_status)
-
-collateral_add = HydraClassOp(add_collateral_operation,
-                              add_collateral_operation_method,
-                              add_collateral_operation_expects,
-                              add_collateral_operation_returns,
-                              add_collateral_operation_expects_header,
-                              add_collateral_operation_returns_header,
-                              add_collateral_operation_status)
-
-collateral_get = HydraClassOp(get_collateral_operation,
-                              get_collateral_operation_method,
-                              get_collateral_operation_expects,
-                              get_collateral_operation_returns,
-                              get_collateral_operation_expects_header,
-                              get_collateral_operation_returns_header,
-                              get_collateral_operation_status)
-
-collateral_delete = HydraClassOp(delete_collateral_operation,
-                                 delete_collateral_operation_method,
-                                 delete_collateral_operation_expects,
-                                 delete_collateral_operation_returns,
-                                 delete_collateral_operation_expects_header,
-                                 delete_collateral_operation_returns_header,
-                                 add_collateral_operation_status)
-
-# adding property & operation to Loan classes
-loan_class.add_supported_prop(Total_balance_prop)
-loan_class.add_supported_prop(Origination_prop)
-loan_class.add_supported_prop(CounterpartyId_prop)
-loan_class.add_supported_op(loan_get)
-loan_class.add_supported_op(loan_post)
-loan_class.add_supported_op(loan_add)
-loan_class.add_supported_op(loan_delete)
-
-# adding property & operation to Borrower classes
-borrower_class.add_supported_prop(LegalEntityIdentifier_prop)
-borrower_class.add_supported_prop(TotalAssets_prop)
-borrower_class.add_supported_prop(DateOfIncorporation_prop)
-borrower_class.add_supported_op(borrower_get)
-borrower_class.add_supported_op(borrower_post)
-borrower_class.add_supported_op(borrower_add)
-borrower_class.add_supported_op(borrower_delete)
-
-# adding borrower collection
-api_doc.add_supported_collection(borrower_collection)
-
-# adding property & operation to Collateral class
-collateral_class.add_supported_prop(CollateralType_prop)
-collateral_class.add_supported_prop(LatestValuationAmount_prop)
-collateral_class.add_supported_prop(ConcernLoan_prop)
-collateral_class.add_supported_op(collateral_get)
-collateral_class.add_supported_op(collateral_add)
-collateral_class.add_supported_op(collateral_post)
-collateral_class.add_supported_op(collateral_delete)
-
-# adding classes to api_doc
-api_doc.add_supported_class(loan_class)
-api_doc.add_supported_class(borrower_class)
-api_doc.add_supported_class(collateral_class)
+counterparty_collection = HydraCollection(collection_name=counterparty_collection_name,
+                                          collection_description=counterparty_collection_description,
+                                          manages=counterparty_collection_managed_by,
+                                          get=True,
+                                          post=True,
+                                          put=True,
+                                          delete=True)
+api_doc.add_supported_collection(counterparty_collection)
 
 api_doc.add_baseResource()
 api_doc.add_baseCollection()

--- a/creditrisk_poc/npl_vocab/NonPerformingLoan.jsonld
+++ b/creditrisk_poc/npl_vocab/NonPerformingLoan.jsonld
@@ -17,14 +17,14 @@
   },
   "@id" : "",
   "@type" : "http://www.w3.org/2002/07/owl#Ontology",
-  "rdf:label": "Non performing loan vocabulary",
-   "rdf:comment" : "",
+  "rdfs:label": "Non performing loan vocabulary",
+   "rdfs:comment" : "",
   "defines" : [
     {
       "@id" : "https://www.openriskmanual.org/ns/nplo.owl#Counterparty",
-      "@type" : "rdfs:class",
-      "rdf:comment": "",
-      "rdf:label": "CounterParty"
+      "@type" : "rdfs:Class",
+      "rdfs:comment": "",
+      "rdfs:label": "CounterParty"
     },
     {
       "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_legal_entity_identifier",
@@ -32,7 +32,7 @@
       "rdfs:comment": "",
       "rdfs:label": "LegalEntityIdentifier",
       "propertyOf": {
-        "@id":  "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+        "@id":  "https://www.openriskmanual.org/ns/nplo.owl#CounterParty"
       },
       "propertyOn": "xsd:string"
     },
@@ -42,7 +42,7 @@
       "rdfs:comment": "",
       "rdfs:label": "TotalAssets",
       "propertyOf": {
-        "@id":  "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+        "@id":  "https://www.openriskmanual.org/ns/nplo.owl#CounterParty"
       },
       "propertyOn": "xsd:decimal"
     },
@@ -52,7 +52,7 @@
       "rdfs:comment": "",
       "rdfs:label": "DateOfIncorporation",
       "propertyOf": {
-        "@id":  "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+        "@id":  "https://www.openriskmanual.org/ns/nplo.owl#CounterParty"
       },
       "propertyOn": "xsd:dateTime"
     },
@@ -60,7 +60,7 @@
       "@id": "https://www.openriskmanual.org/ns/nplo.owl#Loan",
       "@type": "rdfs:Class",
       "rdfs:comment": "",
-      "rdf:label": "Loan"
+      "rdfs:label": "Loan"
     },
     {
       "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_total_balance",
@@ -81,9 +81,9 @@
     },
     {
       "@id": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
-      "@type": "rdfs:class",
-      "rdf:comment": "",
-      "rdf:label": "Collateral"
+      "@type": "rdfs:Class",
+      "rdfs:comment": "",
+      "rdfs:label": "Collateral"
     },
     {
       "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_collateral_type",

--- a/tests/ApiDoc.jsonld
+++ b/tests/ApiDoc.jsonld
@@ -65,9 +65,118 @@
     "possibleStatus": [],
     "supportedClass": [
         {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+            "@type": "hydra:Class",
+            "description": "",
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/FindAction",
+                    "expects": null,
+                    "expectsHeader": [],
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@type": "Status",
+                            "description": "CounterParty class returned.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                    "returnsHeader": [],
+                    "title": "CounterPartyGET"
+                },
+                {
+                    "@type": "http://schema.org/AddAction",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                    "expectsHeader": [],
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@type": "Status",
+                            "description": "CounterParty class Added.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": null,
+                    "returnsHeader": [],
+                    "title": "CounterPartyPUT"
+                },
+                {
+                    "@type": "http://schema.org/UpdateAction",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@type": "Status",
+                            "description": "CounterParty class updated.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": null,
+                    "returnsHeader": [
+                        "Content-Type",
+                        "Content-Length"
+                    ],
+                    "title": "CounterPartyPOST"
+                },
+                {
+                    "@type": "http://schema.org/DeleteAction",
+                    "expects": null,
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@type": "Status",
+                            "description": "CounterParty class Deleted.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": null,
+                    "returnsHeader": [],
+                    "title": "CounterPartyDELETE"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_legal_entity_identifier",
+                    "readable": true,
+                    "required": true,
+                    "title": "LegalEntityIdentifier",
+                    "writeable": true
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_total_assets",
+                    "readable": true,
+                    "required": true,
+                    "title": "TotalAssets",
+                    "writeable": true
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_date_of_incorporation",
+                    "readable": true,
+                    "required": true,
+                    "title": "DateOfIncorporation",
+                    "writeable": true
+                }
+            ],
+            "title": "CounterParty"
+        },
+        {
             "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
             "@type": "hydra:Class",
-            "description": "This class contains the information regarding Loan",
+            "description": "",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/FindAction",
@@ -85,7 +194,25 @@
                     ],
                     "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
                     "returnsHeader": [],
-                    "title": "GetLoan"
+                    "title": "LoanGET"
+                },
+                {
+                    "@type": "http://schema.org/AddAction",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
+                    "expectsHeader": [],
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@type": "Status",
+                            "description": "Loan class Added.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": null,
+                    "returnsHeader": [],
+                    "title": "LoanPUT"
                 },
                 {
                     "@type": "http://schema.org/UpdateAction",
@@ -106,25 +233,7 @@
                         "Content-Type",
                         "Content-Length"
                     ],
-                    "title": "UpdateLoan"
-                },
-                {
-                    "@type": "http://schema.org/AddAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
-                    "expectsHeader": [],
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Loan class updated.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "AddLoan"
+                    "title": "LoanPOST"
                 },
                 {
                     "@type": "http://schema.org/DeleteAction",
@@ -135,20 +244,28 @@
                         {
                             "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                             "@type": "Status",
-                            "description": "Loan class deleted.",
+                            "description": "Loan class Deleted.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
                     "returns": null,
                     "returnsHeader": [],
-                    "title": "DeleteLoan"
+                    "title": "LoanDELETE"
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "property": "NPL:TotalBalance",
+                    "property": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                    "readable": true,
+                    "required": true,
+                    "title": "CounterpartyId",
+                    "writeable": true
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_total_balance",
                     "readable": true,
                     "required": true,
                     "title": "TotalBalance",
@@ -156,133 +273,19 @@
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "NPL:ChannelOfOrigination",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_channel_of_origination",
                     "readable": true,
                     "required": true,
                     "title": "ChannelOfOrigination",
-                    "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                    "readable": true,
-                    "required": true,
-                    "title": "CounterpartyId",
                     "writeable": true
                 }
             ],
             "title": "Loan"
         },
         {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-            "@type": "hydra:Class",
-            "description": "This class contains the information regarding Loan",
-            "supportedOperation": [
-                {
-                    "@type": "http://schema.org/FindAction",
-                    "expects": null,
-                    "expectsHeader": [],
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Borrower class returned.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                    "returnsHeader": [],
-                    "title": "GetBorrower"
-                },
-                {
-                    "@type": "http://schema.org/UpdateAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                    "expectsHeader": [],
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Borrower class updated.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "UpdateBorrower"
-                },
-                {
-                    "@type": "http://schema.org/AddAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                    "expectsHeader": [],
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Borrower class updated.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "AddBorrower"
-                },
-                {
-                    "@type": "http://schema.org/DeleteAction",
-                    "expects": null,
-                    "expectsHeader": [],
-                    "method": "DELETE",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Borrower class deleted.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "DeleteBorrower"
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "property": "NPL:LegalEntityIdentifier",
-                    "readable": true,
-                    "required": true,
-                    "title": "LegalEntityIdentifier",
-                    "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "NPL:TotalAssets",
-                    "readable": true,
-                    "required": true,
-                    "title": "TotalAssets",
-                    "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "NPL:DateOfIncorporation",
-                    "readable": true,
-                    "required": true,
-                    "title": "DateOfIncorporation",
-                    "writeable": true
-                }
-            ],
-            "title": "Borrower"
-        },
-        {
             "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
             "@type": "hydra:Class",
-            "description": "This class contains the information regarding Collateral",
+            "description": "",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/FindAction",
@@ -300,7 +303,7 @@
                     ],
                     "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
                     "returnsHeader": [],
-                    "title": "GetCollateral"
+                    "title": "CollateralGET"
                 },
                 {
                     "@type": "http://schema.org/AddAction",
@@ -311,14 +314,14 @@
                         {
                             "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                             "@type": "Status",
-                            "description": "Collateral class updated.",
+                            "description": "Collateral class Added.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
                     "returns": null,
                     "returnsHeader": [],
-                    "title": "AddCollateral"
+                    "title": "CollateralPUT"
                 },
                 {
                     "@type": "http://schema.org/UpdateAction",
@@ -335,8 +338,11 @@
                         }
                     ],
                     "returns": null,
-                    "returnsHeader": [],
-                    "title": "UpdateCollateral"
+                    "returnsHeader": [
+                        "Content-Type",
+                        "Content-Length"
+                    ],
+                    "title": "CollateralPOST"
                 },
                 {
                     "@type": "http://schema.org/DeleteAction",
@@ -347,20 +353,20 @@
                         {
                             "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                             "@type": "Status",
-                            "description": "Collateral class updated.",
+                            "description": "Collateral class Deleted.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
                     "returns": null,
                     "returnsHeader": [],
-                    "title": "DeleteCollateral"
+                    "title": "CollateralDELETE"
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "property": "NPL:CollateralType",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_collateral_type",
                     "readable": true,
                     "required": true,
                     "title": "CollateralType",
@@ -368,7 +374,7 @@
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "NPL:LatestValuationAmount",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_latest_valuation_amount",
                     "readable": true,
                     "required": true,
                     "title": "LatestValuationAmount",
@@ -411,88 +417,88 @@
             "title": "Collection"
         },
         {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Borrowers",
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty_collection",
             "@type": "Collection",
             "description": "Collection for Borrower class",
             "manages": {
-                "object": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                "object": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                 "property": "rdf:type"
             },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "_:Borrowers_retrieve",
+                    "@id": "_:CounterParty_collection_retrieve",
                     "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all the members of Borrowers",
+                    "description": "Retrieves all the members of CounterParty_collection",
                     "expects": null,
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "returnsHeader": []
                 },
                 {
-                    "@id": "_:Borrowers_create",
+                    "@id": "_:CounterParty_collection_create",
                     "@type": "http://schema.org/AddAction",
-                    "description": "Create new member in Borrowers",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "description": "Create new member in CounterParty_collection",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
                             "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                             "@type": "Status",
-                            "description": "A new member in Borrowers created",
+                            "description": "A new member in CounterParty_collection created",
                             "statusCode": 201,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "returnsHeader": []
                 },
                 {
-                    "@id": "_:Borrowers_update",
+                    "@id": "_:CounterParty_collection_update",
                     "@type": "http://schema.org/UpdateAction",
-                    "description": "Update member of  Borrowers ",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "description": "Update member of  CounterParty_collection ",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
                             "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                             "@type": "Status",
-                            "description": "If the entity was updatedfrom Borrowers.",
+                            "description": "If the entity was updatedfrom CounterParty_collection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "returnsHeader": []
                 },
                 {
-                    "@id": "_:Borrowers_delete",
+                    "@id": "_:CounterParty_collection_delete",
                     "@type": "http://schema.org/DeleteAction",
-                    "description": "Delete member of Borrowers ",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "description": "Delete member of CounterParty_collection ",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "expectsHeader": [],
                     "method": "DELETE",
                     "possibleStatus": [
                         {
                             "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                             "@type": "Status",
-                            "description": "If entity was deletedsuccessfully from Borrowers.",
+                            "description": "If entity was deletedsuccessfully from CounterParty_collection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                     "returnsHeader": []
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "description": "The members of Borrowers",
+                    "description": "The members of CounterParty_collection",
                     "property": "http://www.w3.org/ns/hydra/core#member",
                     "readable": true,
                     "required": false,
@@ -500,7 +506,7 @@
                     "writeable": true
                 }
             ],
-            "title": "Borrowers"
+            "title": "CounterParty_collection"
         },
         {
             "@id": "http://localhost:8080/creditrisk_api#EntryPoint",
@@ -521,23 +527,123 @@
             ],
             "supportedProperty": [
                 {
+                    "hydra:description": "The CounterParty Class",
+                    "hydra:title": "counterparty",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CounterParty",
+                        "@type": "hydra:Link",
+                        "description": "",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "CounterParty",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                        "supportedOperation": [
+                            {
+                                "@id": "counterpartyget",
+                                "@type": "http://schema.org/FindAction",
+                                "description": null,
+                                "expects": null,
+                                "expectsHeader": [],
+                                "label": "CounterPartyGET",
+                                "method": "GET",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@type": "Status",
+                                        "description": "CounterParty class returned.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "counterpartyput",
+                                "@type": "http://schema.org/AddAction",
+                                "description": null,
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                                "expectsHeader": [],
+                                "label": "CounterPartyPUT",
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@type": "Status",
+                                        "description": "CounterParty class Added.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": null,
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "counterpartypost",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": null,
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
+                                "expectsHeader": [],
+                                "label": "CounterPartyPOST",
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@type": "Status",
+                                        "description": "CounterParty class updated.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": null,
+                                "returnsHeader": [
+                                    "Content-Type",
+                                    "Content-Length"
+                                ]
+                            },
+                            {
+                                "@id": "counterpartydelete",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": null,
+                                "expects": null,
+                                "expectsHeader": [],
+                                "label": "CounterPartyDELETE",
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@type": "Status",
+                                        "description": "CounterParty class Deleted.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": null,
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
                     "hydra:description": "The Loan Class",
                     "hydra:title": "loan",
                     "property": {
                         "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Loan",
                         "@type": "hydra:Link",
-                        "description": "This class contains the information regarding Loan",
+                        "description": "",
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
                         "label": "Loan",
                         "range": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
                         "supportedOperation": [
                             {
-                                "@id": "getloan",
+                                "@id": "loanget",
                                 "@type": "http://schema.org/FindAction",
                                 "description": null,
                                 "expects": null,
                                 "expectsHeader": [],
-                                "label": "GetLoan",
+                                "label": "LoanGET",
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
@@ -552,12 +658,32 @@
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "updateloan",
+                                "@id": "loanput",
+                                "@type": "http://schema.org/AddAction",
+                                "description": null,
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
+                                "expectsHeader": [],
+                                "label": "LoanPUT",
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@type": "Status",
+                                        "description": "Loan class Added.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": null,
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "loanpost",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": null,
                                 "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
                                 "expectsHeader": [],
-                                "label": "UpdateLoan",
+                                "label": "LoanPOST",
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
@@ -575,135 +701,18 @@
                                 ]
                             },
                             {
-                                "@id": "addloan",
-                                "@type": "http://schema.org/AddAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
-                                "expectsHeader": [],
-                                "label": "AddLoan",
-                                "method": "PUT",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Loan class updated.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "deleteloan",
+                                "@id": "loandelete",
                                 "@type": "http://schema.org/DeleteAction",
                                 "description": null,
                                 "expects": null,
                                 "expectsHeader": [],
-                                "label": "DeleteLoan",
+                                "label": "LoanDELETE",
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
                                         "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                                         "@type": "Status",
-                                        "description": "Loan class deleted.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            }
-                        ]
-                    },
-                    "readable": true,
-                    "required": null,
-                    "writeable": false
-                },
-                {
-                    "hydra:description": "The Borrower Class",
-                    "hydra:title": "borrower",
-                    "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Borrower",
-                        "@type": "hydra:Link",
-                        "description": "This class contains the information regarding Loan",
-                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "Borrower",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                        "supportedOperation": [
-                            {
-                                "@id": "getborrower",
-                                "@type": "http://schema.org/FindAction",
-                                "description": null,
-                                "expects": null,
-                                "expectsHeader": [],
-                                "label": "GetBorrower",
-                                "method": "GET",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Borrower class returned.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "updateborrower",
-                                "@type": "http://schema.org/UpdateAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                                "expectsHeader": [],
-                                "label": "UpdateBorrower",
-                                "method": "POST",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Borrower class updated.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "addborrower",
-                                "@type": "http://schema.org/AddAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                                "expectsHeader": [],
-                                "label": "AddBorrower",
-                                "method": "PUT",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Borrower class updated.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "deleteborrower",
-                                "@type": "http://schema.org/DeleteAction",
-                                "description": null,
-                                "expects": null,
-                                "expectsHeader": [],
-                                "label": "DeleteBorrower",
-                                "method": "DELETE",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Borrower class deleted.",
+                                        "description": "Loan class Deleted.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
@@ -723,18 +732,18 @@
                     "property": {
                         "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Collateral",
                         "@type": "hydra:Link",
-                        "description": "This class contains the information regarding Collateral",
+                        "description": "",
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
                         "label": "Collateral",
                         "range": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
                         "supportedOperation": [
                             {
-                                "@id": "getcollateral",
+                                "@id": "collateralget",
                                 "@type": "http://schema.org/FindAction",
                                 "description": null,
                                 "expects": null,
                                 "expectsHeader": [],
-                                "label": "GetCollateral",
+                                "label": "CollateralGET",
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
@@ -749,18 +758,18 @@
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "addcollateral",
+                                "@id": "collateralput",
                                 "@type": "http://schema.org/AddAction",
                                 "description": null,
                                 "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
                                 "expectsHeader": [],
-                                "label": "AddCollateral",
+                                "label": "CollateralPUT",
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
                                         "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                                         "@type": "Status",
-                                        "description": "Collateral class updated.",
+                                        "description": "Collateral class Added.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
@@ -769,12 +778,12 @@
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "updatecollateral",
+                                "@id": "collateralpost",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": null,
                                 "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
                                 "expectsHeader": [],
-                                "label": "UpdateCollateral",
+                                "label": "CollateralPOST",
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
@@ -786,21 +795,24 @@
                                     }
                                 ],
                                 "returns": null,
-                                "returnsHeader": []
+                                "returnsHeader": [
+                                    "Content-Type",
+                                    "Content-Length"
+                                ]
                             },
                             {
-                                "@id": "deletecollateral",
+                                "@id": "collateraldelete",
                                 "@type": "http://schema.org/DeleteAction",
                                 "description": null,
                                 "expects": null,
                                 "expectsHeader": [],
-                                "label": "DeleteCollateral",
+                                "label": "CollateralDELETE",
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
                                         "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                                         "@type": "Status",
-                                        "description": "Collateral class updated.",
+                                        "description": "Collateral class Deleted.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
@@ -815,86 +827,86 @@
                     "writeable": false
                 },
                 {
-                    "hydra:description": "The Borrowers collection",
-                    "hydra:title": "borrowers",
+                    "hydra:description": "The CounterParty_collection collection",
+                    "hydra:title": "counterparty_collection",
                     "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Borrowers",
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CounterParty_collection",
                         "@type": "hydra:Link",
-                        "description": "The Borrowers collection",
+                        "description": "The CounterParty_collection collection",
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "Borrowers",
+                        "label": "CounterParty_collection",
                         "manages": {
-                            "object": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                            "object": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                             "property": "rdf:type"
                         },
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Borrowers",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty_collection",
                         "supportedOperation": [
                             {
-                                "@id": "_:borrowers_retrieve",
+                                "@id": "_:counterparty_collection_retrieve",
                                 "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all the members of Borrowers",
+                                "description": "Retrieves all the members of CounterParty_collection",
                                 "expects": null,
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "_:borrowers_create",
+                                "@id": "_:counterparty_collection_create",
                                 "@type": "http://schema.org/AddAction",
-                                "description": "Create new member in Borrowers",
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "description": "Create new member in CounterParty_collection",
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
                                         "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                                         "@type": "Status",
-                                        "description": "A new member in Borrowers created",
+                                        "description": "A new member in CounterParty_collection created",
                                         "statusCode": 201,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "_:borrowers_update",
+                                "@id": "_:counterparty_collection_update",
                                 "@type": "http://schema.org/UpdateAction",
-                                "description": "Update member of  Borrowers ",
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "description": "Update member of  CounterParty_collection ",
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "expectsHeader": [],
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
                                         "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                                         "@type": "Status",
-                                        "description": "If the entity was updatedfrom Borrowers.",
+                                        "description": "If the entity was updatedfrom CounterParty_collection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "_:borrowers_delete",
+                                "@id": "_:counterparty_collection_delete",
                                 "@type": "http://schema.org/DeleteAction",
-                                "description": "Delete member of Borrowers ",
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "description": "Delete member of CounterParty_collection ",
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "expectsHeader": [],
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
                                         "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
                                         "@type": "Status",
-                                        "description": "If entity was deletedsuccessfully from Borrowers.",
+                                        "description": "If entity was deletedsuccessfully from CounterParty_collection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty",
                                 "returnsHeader": []
                             }
                         ]

--- a/tests/mock_portfolio_generator.py
+++ b/tests/mock_portfolio_generator.py
@@ -24,10 +24,8 @@ def borrowers_with_no_loan(apidoc: HydraDoc):
     Generates 100 Borrowers with no loans & no collateral
     """
     for borrower in range(100):
-        dummy_object = gen_dummy_object("Borrower", apidoc)
-        put_request = requests.put("http://localhost:8080/creditrisk_api/Borrower/", json=dummy_object)
-        response = put_request.content.decode("UTF-8")
-        object_id = ast.literal_eval(response).get("iri")
+        dummy_object = gen_dummy_object("CounterParty", apidoc)
+        put_request = requests.put("http://localhost:8080/creditrisk_api/CounterParty/", json=dummy_object)
 
 
 def borrower_with_loan(apidoc: HydraDoc):
@@ -35,10 +33,12 @@ def borrower_with_loan(apidoc: HydraDoc):
     Generate 100 Borrowers with loan & no collateral
     """
     for borrower in range(100):
-        dummy_object = gen_dummy_object("Loan", apidoc)
-        put_request = requests.put("http://localhost:8080/creditrisk_api/Loan/", json=dummy_object)
-        response = put_request.content.decode("UTF-8")
-        object_id = ast.literal_eval(response).get("iri")
+        # Creating Counterparty Object
+        counterparty_dummy_object = gen_dummy_object("CounterParty", apidoc)
+        # Loan object using CounterpartyId
+        loan_dummy_object = gen_dummy_object("Loan", apidoc)
+        loan_dummy_object['CounterpartyId'] = counterparty_dummy_object
+        put_request = requests.put("http://localhost:8080/creditrisk_api/Loan/", json=loan_dummy_object)
 
 
 def borrower_with_loan_and_collateral(apidoc: HydraDoc):
@@ -46,10 +46,15 @@ def borrower_with_loan_and_collateral(apidoc: HydraDoc):
     Generates 100 Borrowers with loan & collateral
     """
     for borrower in range(100):
-        dummy_object = gen_dummy_object("Collateral", apidoc)
-        put_request = requests.put("http://localhost:8080/creditrisk_api/Collateral/", json=dummy_object)
-        response = put_request.content.decode("UTF-8")
-        object_id = ast.literal_eval(response).get("iri")
+        # Creating Counterparty Object
+        counterparty_dummy_object = gen_dummy_object("CounterParty", apidoc)
+        # Creating Loan object using CounterpartyId
+        loan_dummy_object = gen_dummy_object("Loan", apidoc)
+        loan_dummy_object['CounterpartyId'] = counterparty_dummy_object
+        # Creating Collateral dummy object using ConcernLoan
+        collateral_dummy_object = gen_dummy_object("Collateral",apidoc)
+        collateral_dummy_object['ConcernLoan'] = loan_dummy_object
+        put_request = requests.put("http://localhost:8080/creditrisk_api/Collateral", json=collateral_dummy_object)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #15 

As of now, we create all the classes and properties in ApiDoc using docwriter.py manually.
I have created the script which will parse the `NonPerformingLoan.jsonld` and can create hydra classes & properties for ApiDoc.

**NonPerformingLoan.jsonld --> ApiDoc**

Methods used to parse the jsonld-ld are defined in `NPLVocab_parser.py` 
It can be used as:
```python
import NPLVocab_parse as parser

npl_vocab = parser.get_npl_vocab()
classes = parser.get_all_classes(npl_vocab)
hydra_classes = parser.create_hydra_classes(classes)
```
The ApiDoc generated by the new script is tested with the postman. and all the tests are passing as well. 

> We just need to run `docwriter.py` to create new ApiDoc everytime it will generate classes & properties from JSON-LD.

![Screenshot from 2021-06-29 18-44-45](https://user-images.githubusercontent.com/49719371/123823828-28653d80-d91b-11eb-929f-a869313adba6.png)

`mock_porfolio_generator.py` is also refactored.
creating objects in sequence.

**CounterParty --> Loan --> Collateral**

