### PR TITLE
Datatypes for DB implemented

### DIFF
--- a/creditrisk_poc/api_doc/ApiDoc.jsonld
+++ b/creditrisk_poc/api_doc/ApiDoc.jsonld
@@ -66,105 +66,28 @@
     "possibleStatus": [],
     "supportedClass": [
         {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=InsolvencyPractitioner",
             "@type": "hydra:Class",
-            "description": "Collateral Class",
-            "supportedOperation": [
-                {
-                    "@type": "http://schema.org/FindAction",
-                    "expects": null,
-                    "expectsHeader": [],
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://www.w3.org/ns/hydra/core",
-                            "@type": "Status",
-                            "description": "Collateral class returned.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                    "returnsHeader": [],
-                    "title": "CollateralGET"
-                },
-                {
-                    "@type": "http://schema.org/AddAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                    "expectsHeader": [],
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://www.w3.org/ns/hydra/core",
-                            "@type": "Status",
-                            "description": "Collateral class Added.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "CollateralPUT"
-                },
-                {
-                    "@type": "http://schema.org/UpdateAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                    "expectsHeader": [],
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://www.w3.org/ns/hydra/core",
-                            "@type": "Status",
-                            "description": "Collateral class updated.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [
-                        "Content-Type",
-                        "Content-Length"
-                    ],
-                    "title": "CollateralPOST"
-                },
-                {
-                    "@type": "http://schema.org/DeleteAction",
-                    "expects": null,
-                    "expectsHeader": [],
-                    "method": "DELETE",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://www.w3.org/ns/hydra/core",
-                            "@type": "Status",
-                            "description": "Collateral class Deleted.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "CollateralDELETE"
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
-                    "readable": true,
-                    "required": true,
-                    "title": "collateral_concerns_loan",
-                    "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_latest_valuation_amount",
-                    "readable": true,
-                    "required": true,
-                    "title": "has_latest_valuation_amount",
-                    "writeable": true
-                }
-            ],
-            "title": "Collateral"
+            "description": "Insolvency Practitioner Class",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "InsolvencyPractitioner"
+        },
+        {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=CollectionAgent",
+            "@type": "hydra:Class",
+            "description": "Collection Agent class",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "CollectionAgent"
+        },
+        {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCollateral",
+            "@type": "hydra:Class",
+            "description": "General Collateral Class",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "GeneralCollateral"
         },
         {
             "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
@@ -250,7 +173,7 @@
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "property": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "readable": true,
                     "required": true,
                     "title": "CounterpartyId",
@@ -258,123 +181,104 @@
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_total_balance",
+                    "property": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
                     "readable": true,
                     "required": true,
-                    "title": "has_total_balance",
+                    "title": "has_borrower",
                     "writeable": true
                 },
                 {
                     "@type": "SupportedProperty",
                     "property": "https://www.openriskmanual.org/ns/nplo.owl#has_channel_of_origination",
+                    "range": "xsd:_:N64800880ab3041bf88cebabee42ba5aa",
                     "readable": true,
                     "required": true,
                     "title": "has_channel_of_origination",
+                    "writeable": true
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_total_balance",
+                    "range": "xsd:decimal",
+                    "readable": true,
+                    "required": true,
+                    "title": "has_total_balance",
                     "writeable": true
                 }
             ],
             "title": "Loan"
         },
         {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=CorporateLoan",
             "@type": "hydra:Class",
-            "description": "Counterparty Class (not necessarily to a credit contract)",
-            "supportedOperation": [
-                {
-                    "@type": "http://schema.org/FindAction",
-                    "expects": null,
-                    "expectsHeader": [],
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://www.w3.org/ns/hydra/core",
-                            "@type": "Status",
-                            "description": "Counterparty class returned.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                    "returnsHeader": [],
-                    "title": "CounterpartyGET"
-                },
-                {
-                    "@type": "http://schema.org/AddAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                    "expectsHeader": [],
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://www.w3.org/ns/hydra/core",
-                            "@type": "Status",
-                            "description": "Counterparty class Added.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "CounterpartyPUT"
-                },
-                {
-                    "@type": "http://schema.org/UpdateAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                    "expectsHeader": [],
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://www.w3.org/ns/hydra/core",
-                            "@type": "Status",
-                            "description": "Counterparty class updated.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [
-                        "Content-Type",
-                        "Content-Length"
-                    ],
-                    "title": "CounterpartyPOST"
-                },
-                {
-                    "@type": "http://schema.org/DeleteAction",
-                    "expects": null,
-                    "expectsHeader": [],
-                    "method": "DELETE",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://www.w3.org/ns/hydra/core",
-                            "@type": "Status",
-                            "description": "Counterparty class Deleted.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "CounterpartyDELETE"
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_total_assets",
-                    "readable": true,
-                    "required": true,
-                    "title": "has_total_assets",
-                    "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_legal_entity_identifier",
-                    "readable": true,
-                    "required": true,
-                    "title": "has_legal_entity_identifier",
-                    "writeable": true
-                }
-            ],
-            "title": "Counterparty"
+            "description": "Corporate Loan class",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "CorporateLoan"
+        },
+        {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=CreditRatingAgency",
+            "@type": "hydra:Class",
+            "description": "Credit Rating Agency Class",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "CreditRatingAgency"
+        },
+        {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
+            "@type": "hydra:Class",
+            "description": "General Counterparty Class (not necessarily to a credit contract)",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "GeneralCounterparty"
+        },
+        {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+            "@type": "hydra:Class",
+            "description": "Borrower Class. A sub-class of Counterparty that applies to Lending relations",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "Borrower"
+        },
+        {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Receiver",
+            "@type": "hydra:Class",
+            "description": "Receiver Class",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "Receiver"
+        },
+        {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=CorporateBorrower",
+            "@type": "hydra:Class",
+            "description": "Corporate Borrower Class. A sub-class of Borrower that applies to Corporations",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "CorporateBorrower"
+        },
+        {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=PersonalLoan",
+            "@type": "hydra:Class",
+            "description": "Personal Loan class",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "PersonalLoan"
+        },
+        {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=IndividualBorrower",
+            "@type": "hydra:Class",
+            "description": "Individual Borrower Class. A sub-class of Borrower that applies to Individuals",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "IndividualBorrower"
+        },
+        {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=InsuranceProvider",
+            "@type": "hydra:Class",
+            "description": "Insurance Provider Class",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "InsuranceProvider"
         },
         {
             "@id": "http://www.w3.org/ns/hydra/core#Resource",
@@ -406,7 +310,7 @@
             "@type": "Collection",
             "description": "Collection for Borrower class",
             "manages": {
-                "object": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                "object": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                 "property": "rdf:type"
             },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
@@ -419,14 +323,14 @@
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:CounterParty_collection_create",
                     "@type": "http://schema.org/AddAction",
                     "description": "Create new member in CounterParty_collection",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
@@ -438,14 +342,14 @@
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:CounterParty_collection_update",
                     "@type": "http://schema.org/UpdateAction",
                     "description": "Update member of  CounterParty_collection ",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
@@ -457,14 +361,14 @@
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:CounterParty_collection_delete",
                     "@type": "http://schema.org/DeleteAction",
                     "description": "Delete member of CounterParty_collection ",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "expectsHeader": [],
                     "method": "DELETE",
                     "possibleStatus": [
@@ -476,7 +380,7 @@
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "returnsHeader": []
                 }
             ],
@@ -512,100 +416,48 @@
             ],
             "supportedProperty": [
                 {
-                    "hydra:description": "The Collateral Class",
-                    "hydra:title": "collateral",
+                    "hydra:description": "The InsolvencyPractitioner Class",
+                    "hydra:title": "insolvencypractitioner",
                     "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Collateral",
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/InsolvencyPractitioner",
                         "@type": "hydra:Link",
-                        "description": "Collateral Class",
+                        "description": "Insolvency Practitioner Class",
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "Collateral",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                        "supportedOperation": [
-                            {
-                                "@id": "collateralget",
-                                "@type": "http://schema.org/FindAction",
-                                "description": null,
-                                "expects": null,
-                                "expectsHeader": [],
-                                "label": "CollateralGET",
-                                "method": "GET",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://www.w3.org/ns/hydra/core",
-                                        "@type": "Status",
-                                        "description": "Collateral class returned.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "collateralput",
-                                "@type": "http://schema.org/AddAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                                "expectsHeader": [],
-                                "label": "CollateralPUT",
-                                "method": "PUT",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://www.w3.org/ns/hydra/core",
-                                        "@type": "Status",
-                                        "description": "Collateral class Added.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "collateralpost",
-                                "@type": "http://schema.org/UpdateAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                                "expectsHeader": [],
-                                "label": "CollateralPOST",
-                                "method": "POST",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://www.w3.org/ns/hydra/core",
-                                        "@type": "Status",
-                                        "description": "Collateral class updated.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": [
-                                    "Content-Type",
-                                    "Content-Length"
-                                ]
-                            },
-                            {
-                                "@id": "collateraldelete",
-                                "@type": "http://schema.org/DeleteAction",
-                                "description": null,
-                                "expects": null,
-                                "expectsHeader": [],
-                                "label": "CollateralDELETE",
-                                "method": "DELETE",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://www.w3.org/ns/hydra/core",
-                                        "@type": "Status",
-                                        "description": "Collateral class Deleted.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            }
-                        ]
+                        "label": "InsolvencyPractitioner",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=InsolvencyPractitioner",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The CollectionAgent Class",
+                    "hydra:title": "collectionagent",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CollectionAgent",
+                        "@type": "hydra:Link",
+                        "description": "Collection Agent class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "CollectionAgent",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CollectionAgent",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The GeneralCollateral Class",
+                    "hydra:title": "generalcollateral",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/GeneralCollateral",
+                        "@type": "hydra:Link",
+                        "description": "General Collateral Class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "GeneralCollateral",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCollateral",
+                        "supportedOperation": []
                     },
                     "readable": true,
                     "required": null,
@@ -712,100 +564,144 @@
                     "writeable": false
                 },
                 {
-                    "hydra:description": "The Counterparty Class",
-                    "hydra:title": "counterparty",
+                    "hydra:description": "The CorporateLoan Class",
+                    "hydra:title": "corporateloan",
                     "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Counterparty",
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CorporateLoan",
                         "@type": "hydra:Link",
-                        "description": "Counterparty Class (not necessarily to a credit contract)",
+                        "description": "Corporate Loan class",
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "Counterparty",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                        "supportedOperation": [
-                            {
-                                "@id": "counterpartyget",
-                                "@type": "http://schema.org/FindAction",
-                                "description": null,
-                                "expects": null,
-                                "expectsHeader": [],
-                                "label": "CounterpartyGET",
-                                "method": "GET",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://www.w3.org/ns/hydra/core",
-                                        "@type": "Status",
-                                        "description": "Counterparty class returned.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "counterpartyput",
-                                "@type": "http://schema.org/AddAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                                "expectsHeader": [],
-                                "label": "CounterpartyPUT",
-                                "method": "PUT",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://www.w3.org/ns/hydra/core",
-                                        "@type": "Status",
-                                        "description": "Counterparty class Added.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "counterpartypost",
-                                "@type": "http://schema.org/UpdateAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                                "expectsHeader": [],
-                                "label": "CounterpartyPOST",
-                                "method": "POST",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://www.w3.org/ns/hydra/core",
-                                        "@type": "Status",
-                                        "description": "Counterparty class updated.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": [
-                                    "Content-Type",
-                                    "Content-Length"
-                                ]
-                            },
-                            {
-                                "@id": "counterpartydelete",
-                                "@type": "http://schema.org/DeleteAction",
-                                "description": null,
-                                "expects": null,
-                                "expectsHeader": [],
-                                "label": "CounterpartyDELETE",
-                                "method": "DELETE",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://www.w3.org/ns/hydra/core",
-                                        "@type": "Status",
-                                        "description": "Counterparty class Deleted.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            }
-                        ]
+                        "label": "CorporateLoan",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CorporateLoan",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The CreditRatingAgency Class",
+                    "hydra:title": "creditratingagency",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CreditRatingAgency",
+                        "@type": "hydra:Link",
+                        "description": "Credit Rating Agency Class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "CreditRatingAgency",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CreditRatingAgency",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The GeneralCounterparty Class",
+                    "hydra:title": "generalcounterparty",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/GeneralCounterparty",
+                        "@type": "hydra:Link",
+                        "description": "General Counterparty Class (not necessarily to a credit contract)",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "GeneralCounterparty",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The Borrower Class",
+                    "hydra:title": "borrower",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Borrower",
+                        "@type": "hydra:Link",
+                        "description": "Borrower Class. A sub-class of Counterparty that applies to Lending relations",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "Borrower",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The Receiver Class",
+                    "hydra:title": "receiver",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Receiver",
+                        "@type": "hydra:Link",
+                        "description": "Receiver Class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "Receiver",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Receiver",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The CorporateBorrower Class",
+                    "hydra:title": "corporateborrower",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CorporateBorrower",
+                        "@type": "hydra:Link",
+                        "description": "Corporate Borrower Class. A sub-class of Borrower that applies to Corporations",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "CorporateBorrower",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CorporateBorrower",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The PersonalLoan Class",
+                    "hydra:title": "personalloan",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/PersonalLoan",
+                        "@type": "hydra:Link",
+                        "description": "Personal Loan class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "PersonalLoan",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=PersonalLoan",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The IndividualBorrower Class",
+                    "hydra:title": "individualborrower",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/IndividualBorrower",
+                        "@type": "hydra:Link",
+                        "description": "Individual Borrower Class. A sub-class of Borrower that applies to Individuals",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "IndividualBorrower",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=IndividualBorrower",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The InsuranceProvider Class",
+                    "hydra:title": "insuranceprovider",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/InsuranceProvider",
+                        "@type": "hydra:Link",
+                        "description": "Insurance Provider Class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "InsuranceProvider",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=InsuranceProvider",
+                        "supportedOperation": []
                     },
                     "readable": true,
                     "required": null,
@@ -821,7 +717,7 @@
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
                         "label": "CounterParty_collection",
                         "manages": {
-                            "object": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                            "object": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                             "property": "rdf:type"
                         },
                         "range": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty_collection",
@@ -834,14 +730,14 @@
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:counterparty_collection_create",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "Create new member in CounterParty_collection",
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
@@ -853,14 +749,14 @@
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:counterparty_collection_update",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "Update member of  CounterParty_collection ",
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "expectsHeader": [],
                                 "method": "POST",
                                 "possibleStatus": [
@@ -872,14 +768,14 @@
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:counterparty_collection_delete",
                                 "@type": "http://schema.org/DeleteAction",
                                 "description": "Delete member of CounterParty_collection ",
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "expectsHeader": [],
                                 "method": "DELETE",
                                 "possibleStatus": [
@@ -891,7 +787,7 @@
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "returnsHeader": []
                             }
                         ]

--- a/creditrisk_poc/api_doc/ApiDoc.jsonld
+++ b/creditrisk_poc/api_doc/ApiDoc.jsonld
@@ -56,7 +56,8 @@
         "supportedOperation": "hydra:supportedOperation",
         "supportedProperty": "hydra:supportedProperty",
         "title": "hydra:title",
-        "writeable": "hydra:writeable"
+        "writeable": "hydra:writeable",
+        "xsd": "https://www.w3.org/TR/xmlschema-2/#"
     },
     "@id": "http://localhost:8080/creditrisk_api/vocab",
     "@type": "ApiDocumentation",
@@ -76,7 +77,7 @@
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Collateral class returned.",
                             "statusCode": 200,
@@ -94,7 +95,7 @@
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Collateral class Added.",
                             "statusCode": 200,
@@ -112,7 +113,7 @@
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Collateral class updated.",
                             "statusCode": 200,
@@ -133,7 +134,7 @@
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Collateral class Deleted.",
                             "statusCode": 200,
@@ -177,7 +178,7 @@
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Loan class returned.",
                             "statusCode": 200,
@@ -195,7 +196,7 @@
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Loan class Added.",
                             "statusCode": 200,
@@ -213,7 +214,7 @@
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Loan class updated.",
                             "statusCode": 200,
@@ -234,7 +235,7 @@
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Loan class Deleted.",
                             "statusCode": 200,
@@ -286,7 +287,7 @@
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Counterparty class returned.",
                             "statusCode": 200,
@@ -304,7 +305,7 @@
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Counterparty class Added.",
                             "statusCode": 200,
@@ -322,7 +323,7 @@
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Counterparty class updated.",
                             "statusCode": 200,
@@ -343,7 +344,7 @@
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Counterparty class Deleted.",
                             "statusCode": 200,
@@ -430,7 +431,7 @@
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "A new member in CounterParty_collection created",
                             "statusCode": 201,
@@ -449,7 +450,7 @@
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If the entity was updatedfrom CounterParty_collection.",
                             "statusCode": 200,
@@ -468,7 +469,7 @@
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If entity was deletedsuccessfully from CounterParty_collection.",
                             "statusCode": 200,
@@ -531,7 +532,7 @@
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Collateral class returned.",
                                         "statusCode": 200,
@@ -551,7 +552,7 @@
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Collateral class Added.",
                                         "statusCode": 200,
@@ -571,7 +572,7 @@
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Collateral class updated.",
                                         "statusCode": 200,
@@ -594,7 +595,7 @@
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Collateral class Deleted.",
                                         "statusCode": 200,
@@ -631,7 +632,7 @@
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Loan class returned.",
                                         "statusCode": 200,
@@ -651,7 +652,7 @@
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Loan class Added.",
                                         "statusCode": 200,
@@ -671,7 +672,7 @@
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Loan class updated.",
                                         "statusCode": 200,
@@ -694,7 +695,7 @@
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Loan class Deleted.",
                                         "statusCode": 200,
@@ -731,7 +732,7 @@
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Counterparty class returned.",
                                         "statusCode": 200,
@@ -751,7 +752,7 @@
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Counterparty class Added.",
                                         "statusCode": 200,
@@ -771,7 +772,7 @@
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Counterparty class updated.",
                                         "statusCode": 200,
@@ -794,7 +795,7 @@
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Counterparty class Deleted.",
                                         "statusCode": 200,
@@ -845,7 +846,7 @@
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "A new member in CounterParty_collection created",
                                         "statusCode": 201,
@@ -864,7 +865,7 @@
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If the entity was updatedfrom CounterParty_collection.",
                                         "statusCode": 200,
@@ -883,7 +884,7 @@
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If entity was deletedsuccessfully from CounterParty_collection.",
                                         "statusCode": 200,

--- a/creditrisk_poc/api_doc/ApiDoc.jsonld
+++ b/creditrisk_poc/api_doc/ApiDoc.jsonld
@@ -66,20 +66,12 @@
     "possibleStatus": [],
     "supportedClass": [
         {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=InsolvencyPractitioner",
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
             "@type": "hydra:Class",
-            "description": "Insolvency Practitioner Class",
+            "description": "General Counterparty Class (not necessarily to a credit contract)",
             "supportedOperation": [],
             "supportedProperty": [],
-            "title": "InsolvencyPractitioner"
-        },
-        {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=CollectionAgent",
-            "@type": "hydra:Class",
-            "description": "Collection Agent class",
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "CollectionAgent"
+            "title": "GeneralCounterparty"
         },
         {
             "@id": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCollateral",
@@ -181,25 +173,8 @@
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                    "readable": true,
-                    "required": true,
-                    "title": "has_borrower",
-                    "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_channel_of_origination",
-                    "range": "xsd:_:N64800880ab3041bf88cebabee42ba5aa",
-                    "readable": true,
-                    "required": true,
-                    "title": "has_channel_of_origination",
-                    "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
                     "property": "https://www.openriskmanual.org/ns/nplo.owl#has_total_balance",
-                    "range": "xsd:decimal",
+                    "range": "xsd:float",
                     "readable": true,
                     "required": true,
                     "title": "has_total_balance",
@@ -207,86 +182,6 @@
                 }
             ],
             "title": "Loan"
-        },
-        {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=CorporateLoan",
-            "@type": "hydra:Class",
-            "description": "Corporate Loan class",
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "CorporateLoan"
-        },
-        {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=CreditRatingAgency",
-            "@type": "hydra:Class",
-            "description": "Credit Rating Agency Class",
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "CreditRatingAgency"
-        },
-        {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
-            "@type": "hydra:Class",
-            "description": "General Counterparty Class (not necessarily to a credit contract)",
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "GeneralCounterparty"
-        },
-        {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-            "@type": "hydra:Class",
-            "description": "Borrower Class. A sub-class of Counterparty that applies to Lending relations",
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "Borrower"
-        },
-        {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Receiver",
-            "@type": "hydra:Class",
-            "description": "Receiver Class",
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "Receiver"
-        },
-        {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=CorporateBorrower",
-            "@type": "hydra:Class",
-            "description": "Corporate Borrower Class. A sub-class of Borrower that applies to Corporations",
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "CorporateBorrower"
-        },
-        {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=PersonalLoan",
-            "@type": "hydra:Class",
-            "description": "Personal Loan class",
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "PersonalLoan"
-        },
-        {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=IndividualBorrower",
-            "@type": "hydra:Class",
-            "description": "Individual Borrower Class. A sub-class of Borrower that applies to Individuals",
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "IndividualBorrower"
-        },
-        {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=InsuranceProvider",
-            "@type": "hydra:Class",
-            "description": "Insurance Provider Class",
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "InsuranceProvider"
-        },
-        {
-            "@id": "http://www.w3.org/ns/hydra/core#Resource",
-            "@type": "hydra:Class",
-            "description": null,
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "Resource"
         },
         {
             "@id": "http://www.w3.org/ns/hydra/core#Collection",
@@ -416,15 +311,15 @@
             ],
             "supportedProperty": [
                 {
-                    "hydra:description": "The InsolvencyPractitioner Class",
-                    "hydra:title": "insolvencypractitioner",
+                    "hydra:description": "The Receiver Class",
+                    "hydra:title": "receiver",
                     "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/InsolvencyPractitioner",
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Receiver",
                         "@type": "hydra:Link",
-                        "description": "Insolvency Practitioner Class",
+                        "description": "Receiver Class",
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "InsolvencyPractitioner",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=InsolvencyPractitioner",
+                        "label": "Receiver",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Receiver",
                         "supportedOperation": []
                     },
                     "readable": true,
@@ -432,15 +327,63 @@
                     "writeable": false
                 },
                 {
-                    "hydra:description": "The CollectionAgent Class",
-                    "hydra:title": "collectionagent",
+                    "hydra:description": "The GeneralCounterparty Class",
+                    "hydra:title": "generalcounterparty",
                     "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CollectionAgent",
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/GeneralCounterparty",
                         "@type": "hydra:Link",
-                        "description": "Collection Agent class",
+                        "description": "General Counterparty Class (not necessarily to a credit contract)",
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "CollectionAgent",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CollectionAgent",
+                        "label": "GeneralCounterparty",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The CorporateBorrower Class",
+                    "hydra:title": "corporateborrower",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CorporateBorrower",
+                        "@type": "hydra:Link",
+                        "description": "Corporate Borrower Class. A sub-class of Borrower that applies to Corporations",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "CorporateBorrower",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CorporateBorrower",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The PersonalLoan Class",
+                    "hydra:title": "personalloan",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/PersonalLoan",
+                        "@type": "hydra:Link",
+                        "description": "Personal Loan class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "PersonalLoan",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=PersonalLoan",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The CorporateLoan Class",
+                    "hydra:title": "corporateloan",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CorporateLoan",
+                        "@type": "hydra:Link",
+                        "description": "Corporate Loan class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "CorporateLoan",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CorporateLoan",
                         "supportedOperation": []
                     },
                     "readable": true,
@@ -457,6 +400,70 @@
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
                         "label": "GeneralCollateral",
                         "range": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCollateral",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The CreditRatingAgency Class",
+                    "hydra:title": "creditratingagency",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CreditRatingAgency",
+                        "@type": "hydra:Link",
+                        "description": "Credit Rating Agency Class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "CreditRatingAgency",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CreditRatingAgency",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The Borrower Class",
+                    "hydra:title": "borrower",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Borrower",
+                        "@type": "hydra:Link",
+                        "description": "Borrower Class. A sub-class of Counterparty that applies to Lending relations",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "Borrower",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The InsolvencyPractitioner Class",
+                    "hydra:title": "insolvencypractitioner",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/InsolvencyPractitioner",
+                        "@type": "hydra:Link",
+                        "description": "Insolvency Practitioner Class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "InsolvencyPractitioner",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=InsolvencyPractitioner",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The IndividualBorrower Class",
+                    "hydra:title": "individualborrower",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/IndividualBorrower",
+                        "@type": "hydra:Link",
+                        "description": "Individual Borrower Class. A sub-class of Borrower that applies to Individuals",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "IndividualBorrower",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=IndividualBorrower",
                         "supportedOperation": []
                     },
                     "readable": true,
@@ -558,134 +565,6 @@
                                 "returnsHeader": []
                             }
                         ]
-                    },
-                    "readable": true,
-                    "required": null,
-                    "writeable": false
-                },
-                {
-                    "hydra:description": "The CorporateLoan Class",
-                    "hydra:title": "corporateloan",
-                    "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CorporateLoan",
-                        "@type": "hydra:Link",
-                        "description": "Corporate Loan class",
-                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "CorporateLoan",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CorporateLoan",
-                        "supportedOperation": []
-                    },
-                    "readable": true,
-                    "required": null,
-                    "writeable": false
-                },
-                {
-                    "hydra:description": "The CreditRatingAgency Class",
-                    "hydra:title": "creditratingagency",
-                    "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CreditRatingAgency",
-                        "@type": "hydra:Link",
-                        "description": "Credit Rating Agency Class",
-                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "CreditRatingAgency",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CreditRatingAgency",
-                        "supportedOperation": []
-                    },
-                    "readable": true,
-                    "required": null,
-                    "writeable": false
-                },
-                {
-                    "hydra:description": "The GeneralCounterparty Class",
-                    "hydra:title": "generalcounterparty",
-                    "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/GeneralCounterparty",
-                        "@type": "hydra:Link",
-                        "description": "General Counterparty Class (not necessarily to a credit contract)",
-                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "GeneralCounterparty",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
-                        "supportedOperation": []
-                    },
-                    "readable": true,
-                    "required": null,
-                    "writeable": false
-                },
-                {
-                    "hydra:description": "The Borrower Class",
-                    "hydra:title": "borrower",
-                    "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Borrower",
-                        "@type": "hydra:Link",
-                        "description": "Borrower Class. A sub-class of Counterparty that applies to Lending relations",
-                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "Borrower",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
-                        "supportedOperation": []
-                    },
-                    "readable": true,
-                    "required": null,
-                    "writeable": false
-                },
-                {
-                    "hydra:description": "The Receiver Class",
-                    "hydra:title": "receiver",
-                    "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Receiver",
-                        "@type": "hydra:Link",
-                        "description": "Receiver Class",
-                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "Receiver",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Receiver",
-                        "supportedOperation": []
-                    },
-                    "readable": true,
-                    "required": null,
-                    "writeable": false
-                },
-                {
-                    "hydra:description": "The CorporateBorrower Class",
-                    "hydra:title": "corporateborrower",
-                    "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CorporateBorrower",
-                        "@type": "hydra:Link",
-                        "description": "Corporate Borrower Class. A sub-class of Borrower that applies to Corporations",
-                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "CorporateBorrower",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CorporateBorrower",
-                        "supportedOperation": []
-                    },
-                    "readable": true,
-                    "required": null,
-                    "writeable": false
-                },
-                {
-                    "hydra:description": "The PersonalLoan Class",
-                    "hydra:title": "personalloan",
-                    "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/PersonalLoan",
-                        "@type": "hydra:Link",
-                        "description": "Personal Loan class",
-                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "PersonalLoan",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=PersonalLoan",
-                        "supportedOperation": []
-                    },
-                    "readable": true,
-                    "required": null,
-                    "writeable": false
-                },
-                {
-                    "hydra:description": "The IndividualBorrower Class",
-                    "hydra:title": "individualborrower",
-                    "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/IndividualBorrower",
-                        "@type": "hydra:Link",
-                        "description": "Individual Borrower Class. A sub-class of Borrower that applies to Individuals",
-                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "IndividualBorrower",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=IndividualBorrower",
-                        "supportedOperation": []
                     },
                     "readable": true,
                     "required": null,

--- a/creditrisk_poc/api_doc/api_docwriter.py
+++ b/creditrisk_poc/api_doc/api_docwriter.py
@@ -46,9 +46,13 @@ for class_ in hydra_classes:
     for property_ in class_properties:
         prop = parser.create_hydra_properties(property_, classes)
         class_.add_supported_prop(prop)
-    class_operations = eval(class_name + "_operations")
-    for operation in class_operations:
-        class_.add_supported_op(operation)
+    try:
+        class_operations = eval(class_name + "_operations")
+    except NameError:
+        class_operations = None
+    if class_operations:
+        for operation in class_operations:
+            class_.add_supported_op(operation)
     api_doc.add_supported_class(class_)
 
 

--- a/creditrisk_poc/api_doc/api_docwriter.py
+++ b/creditrisk_poc/api_doc/api_docwriter.py
@@ -29,7 +29,7 @@ classes = parser.get_all_classes(npl_vocab)
 hydra_classes = parser.create_hydra_classes(classes)
 classes = {class_.title: class_ for class_ in hydra_classes}
 
-loan_foriegnkey_uri = classes['Counterparty'].id_
+loan_foriegnkey_uri = classes['GeneralCounterparty'].id_
 loan_foriegnkey_title = "CounterpartyId"
 CounterpartyId_prop = HydraClassProp(loan_foriegnkey_uri, loan_foriegnkey_title,
                                      required=True, read=True, write=True)
@@ -64,7 +64,7 @@ counterparty_collection_title = "CounterParty class collection"
 counterparty_collection_description = "Collection for Borrower class"
 counterparty_collection_managed_by = {
     "property": "rdf:type",
-    "object": parser.get_class_id("Counterparty", hydra_classes),
+    "object": parser.get_class_id("GeneralCounterparty", hydra_classes),
 }
 counterparty_collection = HydraCollection(collection_name=counterparty_collection_name,
                                           collection_description=counterparty_collection_description,

--- a/creditrisk_poc/api_doc/nplvocab_parser.py
+++ b/creditrisk_poc/api_doc/nplvocab_parser.py
@@ -53,18 +53,20 @@ def get_class_properties(class_name: str, vocab: dict) -> list:
 
 
 def create_hydra_properties(property_: dict, hydra_classes: dict) -> HydraClassProp:
-    property_uri = None
-    property_name = None
     if property_['@type'] == 'owl:DatatypeProperty':
-        property_uri = property_['@id']
-        property_name = property_['rdfs:label']
+        try:
+            prop_range = "xsd:" + property_['propertyOn'].split('#')[1]
+        except Exception:
+            prop_range = "xsd:" + property_['propertyOn']
+        hydra_property = HydraClassProp(property_['@id'], property_['rdfs:label'], range=prop_range,
+                                        required=True, read=True, write=True)
     elif 'owl:ObjectProperty' in property_['@type']:
         property_on_class = property_.get("propertyOn").split('#')[1]
         property_uri = hydra_classes[property_on_class].id_
         property_name = property_['@id'].split('#')[1]
+        hydra_property = HydraClassProp(property_uri, property_name,
+                                        required=True, read=True, write=True)
 
-    hydra_property = HydraClassProp(property_uri, property_name,
-                                    required=True, read=True, write=True)
     return hydra_property
 
 

--- a/creditrisk_poc/npl_vocab/NonPerformingLoan.jsonld
+++ b/creditrisk_poc/npl_vocab/NonPerformingLoan.jsonld
@@ -17,6 +17,433 @@
     },
     "@graph": [
         {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_legal_entity_identifier",
+            "@type": "owl:DatatypeProperty",
+            "owl:versionInfo": "0.1",
+            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty",
+            "propertyOn": "http://www.w3.org/2001/XMLSchema#string",
+            "rdfs:comment": [
+                "Global standard 20-character corporate identifier of the Corporate Counterparty",
+                "EBA 1.1 Field Index: 3.035"
+            ],
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:label": "has_legal_entity_identifier",
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.Counterparty.Legal_Entity_Identifier",
+            "rdfs:subPropertyOf": [
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Moderate"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#VariableConfidentiality"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static"
+                }
+            ]
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#InsolvencyPractitioner",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Insolvency Practitioner Class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Insolvency_Practitioner",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#CollectionAgent",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Collection Agent class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Debt_Collection",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "General Collateral Class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Collateral",
+            "rdfs:subClassOf": {
+                "@id": "owl:Thing"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#collateral_concerns_loan",
+            "@type": [
+                "owl:ObjectProperty",
+                "owl:FunctionalProperty"
+            ],
+            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
+            "propertyOn": "https://www.openriskmanual.org/ns/nplo.owl#Loan"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Loan",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Loan class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Loan",
+            "rdfs:subClassOf": {
+                "@id": "owl:Thing"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Current",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Temporality"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#CorporateLoan",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Corporate Loan class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Corporate_Loan",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Loan"
+            }
+        },
+        {
+            "@id": "http://purl.org/dc/elements/1.1/description",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#VariableConfidentiality",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Confidentiality"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Variability"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Variability",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Temporality",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Dynamic",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Variability"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#RatingAgency",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Credit Rating Agency Class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Credit_Rating_Agency",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "General Counterparty Class (not necessarily to a credit contract)",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Counterparty",
+            "rdfs:subClassOf": {
+                "@id": "owl:Thing"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Borrower",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Borrower Class. A sub-class of Counterparty that applies to Lending relations",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Borrower",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_borrower",
+            "@type": "owl:ObjectProperty",
+            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Loan",
+            "propertyOn": "https://www.openriskmanual.org/ns/nplo.owl#Borrower"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl",
+            "@type": "owl:Ontology",
+            "http://purl.org/dc/elements/1.1/creator": "Open Risk (https://www.openriskmanagement.com)",
+            "http://purl.org/dc/elements/1.1/description": "The Non Performing Loan ontology, described using W3C RDF Schema and the Web Ontology Language OWL. \n\nNPLO aims to conform as closely as possible to the published European Banking Authority NPL Data Templates\n\nRelease Notes:\n- Version 0.1 Defines the main classes, object and data properties of the ontology",
+            "http://purl.org/dc/elements/1.1/format": "application/rdf+xml",
+            "http://purl.org/dc/elements/1.1/rights": "Copyright \u00a9 2021 Open Risk",
+            "http://purl.org/dc/elements/1.1/title": "Non Performing Loan Ontology (NPLO)",
+            "http://purl.org/dc/terms/license": "Creative Commons Attribution 3.0 (CC BY 3.0)",
+            "owl:versionIRI": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "The Non Performing Loan Ontology is still in active development. Feedback, ideas, use cases are encouraged",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL_Template"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Critical",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Importance"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Receiver",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Receiver Class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Receiver",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#CorporateBorrower",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Corporate Borrower Class. A sub-class of Borrower that applies to Corporations",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Corporate_Borrower",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Borrower"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_collateral_type",
+            "@type": "owl:DatatypeProperty",
+            "owl:versionInfo": "0.1",
+            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
+            "propertyOn": "_:N1353286f13eb43478f3d27fd1d7e679d",
+            "rdfs:comment": [
+                "Physical type of the Collateral, e.g. Guarantee and Machinery",
+                "EBA 1.1 Field Index: 14.004"
+            ],
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:label": "has_collateral_type",
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.NonProperty_Collateral.Collateral_Type",
+            "rdfs:subPropertyOf": [
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Critical"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static"
+                }
+            ]
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_channel_of_origination",
+            "@type": "owl:DatatypeProperty",
+            "owl:versionInfo": "0.1",
+            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Loan",
+            "propertyOn": "_:N64800880ab3041bf88cebabee42ba5aa",
+            "rdfs:comment": [
+                "Channel through which the Loan was originated, i.e. Branch, Internet and Broker",
+                "EBA 1.1 Field Index: 7.002"
+            ],
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:label": "has_channel_of_origination",
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.Loan.Channel_of_Origination",
+            "rdfs:subPropertyOf": [
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Important"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static"
+                }
+            ]
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#PersonalLoan",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Personal Loan class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Personal_Loan",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Loan"
+            }
+        },
+        {
+            "@id": "http://purl.org/dc/elements/1.1/format",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Confidentiality",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute",
+            "@type": "owl:DatatypeProperty"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#IndividualBorrower",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Individual Borrower Class. A sub-class of Borrower that applies to Individuals",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Corporate_Borrower",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Borrower"
+            }
+        },
+        {
+            "@id": "http://purl.org/dc/terms/title",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "http://purl.org/dc/elements/1.1/rights",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_latest_valuation_amount",
+            "@type": "owl:DatatypeProperty",
+            "owl:versionInfo": "0.1",
+            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
+            "propertyOn": "http://www.w3.org/2001/XMLSchema#decimal",
+            "rdfs:comment": [
+                "EBA 1.1 Field Index: 14.014",
+                "Value of the Collateral when last assessed"
+            ],
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:label": "has_latest_valuation_amount",
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.NonProperty_Collateral.Latest_Valuation_Amount",
+            "rdfs:subPropertyOf": [
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Critical"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Dynamic"
+                }
+            ]
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Moderate",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Importance"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Important",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Importance"
+            }
+        },
+        {
+            "@id": "http://purl.org/dc/terms/license",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Confidentiality"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Historical",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Temporality"
+            }
+        },
+        {
+            "@id": "http://purl.org/dc/elements/1.1/creator",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#InsuranceProvider",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Insurance Provider Class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Insurance_Company",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+            }
+        },
+        {
+            "@id": "http://purl.org/dc/elements/1.1/title",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
             "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_total_assets",
             "@type": "owl:DatatypeProperty",
             "owl:versionInfo": "0.1",
@@ -44,27 +471,17 @@
             ]
         },
         {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Future",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Temporality"
+            }
+        },
+        {
             "@id": "https://www.openriskmanual.org/ns/nplo.owl#Importance",
             "@type": "owl:DatatypeProperty",
             "rdfs:subPropertyOf": {
                 "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute"
-            }
-        },
-        {
-            "@id": "http://purl.org/dc/terms/license",
-            "@type": "owl:AnnotationProperty"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Collateral Class",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Collateral",
-            "rdfs:subClassOf": {
-                "@id": "owl:Thing"
             }
         },
         {
@@ -74,8 +491,8 @@
             "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Loan",
             "propertyOn": "http://www.w3.org/2001/XMLSchema#decimal",
             "rdfs:comment": [
-                "EBA 1.1 Field Index: 7.02",
-                "Total unpaid balance, i.e. Principal Balance + Accrued Interest Balance (On book) + Other Balances"
+                "Total unpaid balance, i.e. Principal Balance + Accrued Interest Balance (On book) + Other Balances",
+                "EBA 1.1 Field Index: 7.02"
             ],
             "rdfs:isDefinedBy": {
                 "@id": "https://www.openriskmanual.org/ns/nplo.owl"
@@ -93,153 +510,6 @@
                     "@id": "https://www.openriskmanual.org/ns/nplo.owl#Critical"
                 }
             ]
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Loan",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Loan class",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Loan",
-            "rdfs:subClassOf": {
-                "@id": "owl:Thing"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_channel_of_origination",
-            "@type": "owl:DatatypeProperty",
-            "owl:versionInfo": "0.1",
-            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Loan",
-            "propertyOn": "_:N3e26d9a6cc6c4029b44cae2a7856c1d7",
-            "rdfs:comment": [
-                "EBA 1.1 Field Index: 7.002",
-                "Channel through which the Loan was originated, i.e. Branch, Internet and Broker"
-            ],
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:label": "has_channel_of_origination",
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.Loan.Channel_of_Origination",
-            "rdfs:subPropertyOf": [
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Important"
-                }
-            ]
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Counterparty Class (not necessarily to a credit contract)",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Counterparty",
-            "rdfs:subClassOf": {
-                "@id": "owl:Thing"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl",
-            "@type": "owl:Ontology",
-            "http://purl.org/dc/elements/1.1/creator": "Open Risk (https://www.openriskmanagement.com)",
-            "http://purl.org/dc/elements/1.1/description": "The Non Performing Loan ontology, described using W3C RDF Schema and the Web Ontology Language OWL. \n\nNPLO aims to conform as closely as possible to the published European Banking Authority NPL Data Templates\n\nRelease Notes:\n- Version 0.1 Defines the main classes, object and data properties of the ontology",
-            "http://purl.org/dc/elements/1.1/format": "application/rdf+xml",
-            "http://purl.org/dc/elements/1.1/rights": "Copyright \u00a9 2021 Open Risk",
-            "http://purl.org/dc/elements/1.1/title": "Non Performing Loan Ontology (NPLO)",
-            "http://purl.org/dc/terms/license": "Creative Commons Attribution 3.0 (CC BY 3.0)",
-            "owl:versionIRI": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "The Non Performing Loan Ontology is still in active development. Feedback, ideas, use cases are encouraged",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL_Template"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_legal_entity_identifier",
-            "@type": "owl:DatatypeProperty",
-            "owl:versionInfo": "0.1",
-            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty",
-            "propertyOn": "http://www.w3.org/2001/XMLSchema#string",
-            "rdfs:comment": [
-                "Global standard 20-character corporate identifier of the Corporate Counterparty",
-                "EBA 1.1 Field Index: 3.035"
-            ],
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:label": "has_legal_entity_identifier",
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.Counterparty.Legal_Entity_Identifier",
-            "rdfs:subPropertyOf": [
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#VariableConfidentiality"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Moderate"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static"
-                }
-            ]
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#collateral_concerns_loan",
-            "@type": [
-                "owl:ObjectProperty",
-                "owl:FunctionalProperty"
-            ],
-            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
-            "propertyOn": "https://www.openriskmanual.org/ns/nplo.owl#Loan"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_latest_valuation_amount",
-            "@type": "owl:DatatypeProperty",
-            "owl:versionInfo": "0.1",
-            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
-            "propertyOn": "http://www.w3.org/2001/XMLSchema#decimal",
-            "rdfs:comment": [
-                "Value of the Collateral when last assessed",
-                "EBA 1.1 Field Index: 14.014"
-            ],
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:label": "has_latest_valuation_amount",
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.NonProperty_Collateral.Latest_Valuation_Amount",
-            "rdfs:subPropertyOf": [
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Critical"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Dynamic"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential"
-                }
-            ]
-        },
-        {
-            "@id": "http://purl.org/dc/terms/title",
-            "@type": "owl:AnnotationProperty"
-        },
-        {
-            "@id": "http://purl.org/dc/elements/1.1/format",
-            "@type": "owl:AnnotationProperty"
-        },
-        {
-            "@id": "http://purl.org/dc/elements/1.1/title",
-            "@type": "owl:AnnotationProperty"
         }
     ]
 }

--- a/creditrisk_poc/npl_vocab/NonPerformingLoan.jsonld
+++ b/creditrisk_poc/npl_vocab/NonPerformingLoan.jsonld
@@ -17,161 +17,14 @@
     },
     "@graph": [
         {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_legal_entity_identifier",
-            "@type": "owl:DatatypeProperty",
-            "owl:versionInfo": "0.1",
-            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty",
-            "propertyOn": "http://www.w3.org/2001/XMLSchema#string",
-            "rdfs:comment": [
-                "Global standard 20-character corporate identifier of the Corporate Counterparty",
-                "EBA 1.1 Field Index: 3.035"
-            ],
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:label": "has_legal_entity_identifier",
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.Counterparty.Legal_Entity_Identifier",
-            "rdfs:subPropertyOf": [
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Moderate"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#VariableConfidentiality"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static"
-                }
-            ]
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#InsolvencyPractitioner",
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Receiver",
             "@type": "owl:Class",
             "owl:versionInfo": "0.1",
-            "rdfs:comment": "Insolvency Practitioner Class",
+            "rdfs:comment": "Receiver Class",
             "rdfs:isDefinedBy": {
                 "@id": "https://www.openriskmanual.org/ns/nplo.owl"
             },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Insolvency_Practitioner",
-            "rdfs:subClassOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#CollectionAgent",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Collection Agent class",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Debt_Collection",
-            "rdfs:subClassOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "General Collateral Class",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Collateral",
-            "rdfs:subClassOf": {
-                "@id": "owl:Thing"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#collateral_concerns_loan",
-            "@type": [
-                "owl:ObjectProperty",
-                "owl:FunctionalProperty"
-            ],
-            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
-            "propertyOn": "https://www.openriskmanual.org/ns/nplo.owl#Loan"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Loan",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Loan class",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Loan",
-            "rdfs:subClassOf": {
-                "@id": "owl:Thing"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Current",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Temporality"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#CorporateLoan",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Corporate Loan class",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Corporate_Loan",
-            "rdfs:subClassOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Loan"
-            }
-        },
-        {
-            "@id": "http://purl.org/dc/elements/1.1/description",
-            "@type": "owl:AnnotationProperty"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#VariableConfidentiality",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Confidentiality"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Variability"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Variability",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Temporality",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Dynamic",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Variability"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#RatingAgency",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Credit Rating Agency Class",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Credit_Rating_Agency",
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Receiver",
             "rdfs:subClassOf": {
                 "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
             }
@@ -187,301 +40,6 @@
             "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Counterparty",
             "rdfs:subClassOf": {
                 "@id": "owl:Thing"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Borrower",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Borrower Class. A sub-class of Counterparty that applies to Lending relations",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Borrower",
-            "rdfs:subClassOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_borrower",
-            "@type": "owl:ObjectProperty",
-            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Loan",
-            "propertyOn": "https://www.openriskmanual.org/ns/nplo.owl#Borrower"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl",
-            "@type": "owl:Ontology",
-            "http://purl.org/dc/elements/1.1/creator": "Open Risk (https://www.openriskmanagement.com)",
-            "http://purl.org/dc/elements/1.1/description": "The Non Performing Loan ontology, described using W3C RDF Schema and the Web Ontology Language OWL. \n\nNPLO aims to conform as closely as possible to the published European Banking Authority NPL Data Templates\n\nRelease Notes:\n- Version 0.1 Defines the main classes, object and data properties of the ontology",
-            "http://purl.org/dc/elements/1.1/format": "application/rdf+xml",
-            "http://purl.org/dc/elements/1.1/rights": "Copyright \u00a9 2021 Open Risk",
-            "http://purl.org/dc/elements/1.1/title": "Non Performing Loan Ontology (NPLO)",
-            "http://purl.org/dc/terms/license": "Creative Commons Attribution 3.0 (CC BY 3.0)",
-            "owl:versionIRI": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "The Non Performing Loan Ontology is still in active development. Feedback, ideas, use cases are encouraged",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL_Template"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Critical",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Importance"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Receiver",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Receiver Class",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Receiver",
-            "rdfs:subClassOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#CorporateBorrower",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Corporate Borrower Class. A sub-class of Borrower that applies to Corporations",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Corporate_Borrower",
-            "rdfs:subClassOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Borrower"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_collateral_type",
-            "@type": "owl:DatatypeProperty",
-            "owl:versionInfo": "0.1",
-            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
-            "propertyOn": "_:N1353286f13eb43478f3d27fd1d7e679d",
-            "rdfs:comment": [
-                "Physical type of the Collateral, e.g. Guarantee and Machinery",
-                "EBA 1.1 Field Index: 14.004"
-            ],
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:label": "has_collateral_type",
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.NonProperty_Collateral.Collateral_Type",
-            "rdfs:subPropertyOf": [
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Critical"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static"
-                }
-            ]
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_channel_of_origination",
-            "@type": "owl:DatatypeProperty",
-            "owl:versionInfo": "0.1",
-            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Loan",
-            "propertyOn": "_:N64800880ab3041bf88cebabee42ba5aa",
-            "rdfs:comment": [
-                "Channel through which the Loan was originated, i.e. Branch, Internet and Broker",
-                "EBA 1.1 Field Index: 7.002"
-            ],
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:label": "has_channel_of_origination",
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.Loan.Channel_of_Origination",
-            "rdfs:subPropertyOf": [
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Important"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static"
-                }
-            ]
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#PersonalLoan",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Personal Loan class",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Personal_Loan",
-            "rdfs:subClassOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Loan"
-            }
-        },
-        {
-            "@id": "http://purl.org/dc/elements/1.1/format",
-            "@type": "owl:AnnotationProperty"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Confidentiality",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute",
-            "@type": "owl:DatatypeProperty"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#IndividualBorrower",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Individual Borrower Class. A sub-class of Borrower that applies to Individuals",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Corporate_Borrower",
-            "rdfs:subClassOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Borrower"
-            }
-        },
-        {
-            "@id": "http://purl.org/dc/terms/title",
-            "@type": "owl:AnnotationProperty"
-        },
-        {
-            "@id": "http://purl.org/dc/elements/1.1/rights",
-            "@type": "owl:AnnotationProperty"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_latest_valuation_amount",
-            "@type": "owl:DatatypeProperty",
-            "owl:versionInfo": "0.1",
-            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
-            "propertyOn": "http://www.w3.org/2001/XMLSchema#decimal",
-            "rdfs:comment": [
-                "EBA 1.1 Field Index: 14.014",
-                "Value of the Collateral when last assessed"
-            ],
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:label": "has_latest_valuation_amount",
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.NonProperty_Collateral.Latest_Valuation_Amount",
-            "rdfs:subPropertyOf": [
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Critical"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Dynamic"
-                }
-            ]
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Moderate",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Importance"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Important",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Importance"
-            }
-        },
-        {
-            "@id": "http://purl.org/dc/terms/license",
-            "@type": "owl:AnnotationProperty"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Confidentiality"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Historical",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Temporality"
-            }
-        },
-        {
-            "@id": "http://purl.org/dc/elements/1.1/creator",
-            "@type": "owl:AnnotationProperty"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#InsuranceProvider",
-            "@type": "owl:Class",
-            "owl:versionInfo": "0.1",
-            "rdfs:comment": "Insurance Provider Class",
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Insurance_Company",
-            "rdfs:subClassOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
-            }
-        },
-        {
-            "@id": "http://purl.org/dc/elements/1.1/title",
-            "@type": "owl:AnnotationProperty"
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_total_assets",
-            "@type": "owl:DatatypeProperty",
-            "owl:versionInfo": "0.1",
-            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty",
-            "propertyOn": "http://www.w3.org/2001/XMLSchema#decimal",
-            "rdfs:comment": [
-                "EBA 1.1 Field Index: 3.052",
-                "Amount of total assets held by the Corporate Counterparty as per the latest available financial statements"
-            ],
-            "rdfs:isDefinedBy": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
-            },
-            "rdfs:label": "has_total_assets",
-            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.Counterparty.Total_Assets",
-            "rdfs:subPropertyOf": [
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Important"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Dynamic"
-                },
-                {
-                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential"
-                }
-            ]
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Future",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Temporality"
-            }
-        },
-        {
-            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Importance",
-            "@type": "owl:DatatypeProperty",
-            "rdfs:subPropertyOf": {
-                "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute"
             }
         },
         {
@@ -510,6 +68,408 @@
                     "@id": "https://www.openriskmanual.org/ns/nplo.owl#Critical"
                 }
             ]
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#CorporateBorrower",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Corporate Borrower Class. A sub-class of Borrower that applies to Corporations",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Corporate_Borrower",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Borrower"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Importance",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Confidentiality",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Variability"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Critical",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Importance"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#PersonalLoan",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Personal Loan class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Personal_Loan",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Loan"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#VariableConfidentiality",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Confidentiality"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Future",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Temporality"
+            }
+        },
+        {
+            "@id": "http://purl.org/dc/elements/1.1/title",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#CorporateLoan",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Corporate Loan class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Corporate_Loan",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Loan"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Current",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Temporality"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Variability",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_legal_entity_identifier",
+            "@type": "owl:DatatypeProperty",
+            "owl:versionInfo": "0.1",
+            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty",
+            "propertyOn": "http://www.w3.org/2001/XMLSchema#string",
+            "rdfs:comment": [
+                "Global standard 20-character corporate identifier of the Corporate Counterparty",
+                "EBA 1.1 Field Index: 3.035"
+            ],
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:label": "has_legal_entity_identifier",
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.Counterparty.Legal_Entity_Identifier",
+            "rdfs:subPropertyOf": [
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#VariableConfidentiality"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Moderate"
+                }
+            ]
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute",
+            "@type": "owl:DatatypeProperty"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_latest_valuation_amount",
+            "@type": "owl:DatatypeProperty",
+            "owl:versionInfo": "0.1",
+            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
+            "propertyOn": "http://www.w3.org/2001/XMLSchema#decimal",
+            "rdfs:comment": [
+                "Value of the Collateral when last assessed",
+                "EBA 1.1 Field Index: 14.014"
+            ],
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:label": "has_latest_valuation_amount",
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.NonProperty_Collateral.Latest_Valuation_Amount",
+            "rdfs:subPropertyOf": [
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Critical"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Dynamic"
+                }
+            ]
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "General Collateral Class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Collateral",
+            "rdfs:subClassOf": {
+                "@id": "owl:Thing"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#RatingAgency",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Credit Rating Agency Class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Credit_Rating_Agency",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+            }
+        },
+        {
+            "@id": "http://purl.org/dc/elements/1.1/rights",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "http://purl.org/dc/terms/title",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Borrower",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Borrower Class. A sub-class of Counterparty that applies to Lending relations",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Borrower",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Confidentiality"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Historical",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Temporality"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#InsolvencyPractitioner",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Insolvency Practitioner Class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Insolvency_Practitioner",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+            }
+        },
+        {
+            "@id": "http://purl.org/dc/elements/1.1/description",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "http://purl.org/dc/elements/1.1/format",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_borrower",
+            "@type": "owl:ObjectProperty",
+            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Loan",
+            "propertyOn": "https://www.openriskmanual.org/ns/nplo.owl#Borrower"
+        },
+        {
+            "@id": "http://purl.org/dc/elements/1.1/creator",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Moderate",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Importance"
+            }
+        },
+        {
+            "@id": "http://purl.org/dc/terms/license",
+            "@type": "owl:AnnotationProperty"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#IndividualBorrower",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Individual Borrower Class. A sub-class of Borrower that applies to Individuals",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Corporate_Borrower",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Borrower"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#collateral_concerns_loan",
+            "@type": [
+                "owl:FunctionalProperty",
+                "owl:ObjectProperty"
+            ],
+            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
+            "propertyOn": "https://www.openriskmanual.org/ns/nplo.owl#Loan"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Temporality",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#DataAttribute"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Important",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Importance"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl",
+            "@type": "owl:Ontology",
+            "http://purl.org/dc/elements/1.1/creator": "Open Risk (https://www.openriskmanagement.com)",
+            "http://purl.org/dc/elements/1.1/description": "The Non Performing Loan ontology, described using W3C RDF Schema and the Web Ontology Language OWL. \n\nNPLO aims to conform as closely as possible to the published European Banking Authority NPL Data Templates\n\nRelease Notes:\n- Version 0.1 Defines the main classes, object and data properties of the ontology",
+            "http://purl.org/dc/elements/1.1/format": "application/rdf+xml",
+            "http://purl.org/dc/elements/1.1/rights": "Copyright \u00a9 2021 Open Risk",
+            "http://purl.org/dc/elements/1.1/title": "Non Performing Loan Ontology (NPLO)",
+            "http://purl.org/dc/terms/license": "Creative Commons Attribution 3.0 (CC BY 3.0)",
+            "owl:versionIRI": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "The Non Performing Loan Ontology is still in active development. Feedback, ideas, use cases are encouraged",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL_Template"
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_collateral_type",
+            "@type": "owl:DatatypeProperty",
+            "owl:versionInfo": "0.1",
+            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Collateral",
+            "propertyOn": "_:N9cbe4ed0ba2a4ecdb32d5bf6123edccd",
+            "rdfs:comment": [
+                "EBA 1.1 Field Index: 14.004",
+                "Physical type of the Collateral, e.g. Guarantee and Machinery"
+            ],
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:label": "has_collateral_type",
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.NonProperty_Collateral.Collateral_Type",
+            "rdfs:subPropertyOf": [
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Static"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Critical"
+                }
+            ]
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Loan",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Loan class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Loan",
+            "rdfs:subClassOf": {
+                "@id": "owl:Thing"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#has_total_assets",
+            "@type": "owl:DatatypeProperty",
+            "owl:versionInfo": "0.1",
+            "propertyOf": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty",
+            "propertyOn": "http://www.w3.org/2001/XMLSchema#decimal",
+            "rdfs:comment": [
+                "EBA 1.1 Field Index: 3.052",
+                "Amount of total assets held by the Corporate Counterparty as per the latest available financial statements"
+            ],
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:label": "has_total_assets",
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/EBA_NPL.Counterparty.Total_Assets",
+            "rdfs:subPropertyOf": [
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Dynamic"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#Important"
+                },
+                {
+                    "@id": "https://www.openriskmanual.org/ns/nplo.owl#NonConfidential"
+                }
+            ]
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#Dynamic",
+            "@type": "owl:DatatypeProperty",
+            "rdfs:subPropertyOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Variability"
+            }
+        },
+        {
+            "@id": "https://www.openriskmanual.org/ns/nplo.owl#InsuranceProvider",
+            "@type": "owl:Class",
+            "owl:versionInfo": "0.1",
+            "rdfs:comment": "Insurance Provider Class",
+            "rdfs:isDefinedBy": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl"
+            },
+            "rdfs:seeAlso": "https://www.openriskmanual.org/wiki/Insurance_Company",
+            "rdfs:subClassOf": {
+                "@id": "https://www.openriskmanual.org/ns/nplo.owl#Counterparty"
+            }
         }
     ]
 }

--- a/creditrisk_poc/npl_vocab/vocab_generator.py
+++ b/creditrisk_poc/npl_vocab/vocab_generator.py
@@ -3,6 +3,8 @@ This script will generate the NonPerformingLoan.jsonld from the owl ontology.
 """
 import json
 import rdflib
+from os.path import abspath, dirname
+from pathlib import Path
 
 
 def context() -> dict:
@@ -49,4 +51,7 @@ def generate_jsonld(file_path: str, export_file_name: str):
 if __name__ == '__main__':
     ontology_file = "NonPerformingLoan.owl"
     export_file = "NonPerformingLoan.jsonld"
-    generate_jsonld("npl_vocab/" + ontology_file, "npl_vocab/" + export_file)
+    cwd_path = Path(dirname(dirname(abspath(__file__))))
+    ontology_file_path = cwd_path / "npl_vocab" / ontology_file
+    export_file_path = cwd_path / "npl_vocab" / export_file
+    generate_jsonld(str(ontology_file_path), str(export_file_path))

--- a/creditrisk_poc/npl_vocab/vocab_generator.py
+++ b/creditrisk_poc/npl_vocab/vocab_generator.py
@@ -47,4 +47,6 @@ def generate_jsonld(file_path: str, export_file_name: str):
 
 
 if __name__ == '__main__':
-    generate_jsonld("NonPerformingLoan.owl", "NonPerformingLoan.jsonld")
+    ontology_file = "NonPerformingLoan.owl"
+    export_file = "NonPerformingLoan.jsonld"
+    generate_jsonld("npl_vocab/" + ontology_file, "npl_vocab/" + export_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-hydra-python-core==0.3
-hydrus==0.4.3
+hydra-python-core==0.3.1
+hydrus==0.4.4
 PyLD==2.0.3

--- a/tests/ApiDoc.jsonld
+++ b/tests/ApiDoc.jsonld
@@ -56,7 +56,8 @@
         "supportedOperation": "hydra:supportedOperation",
         "supportedProperty": "hydra:supportedProperty",
         "title": "hydra:title",
-        "writeable": "hydra:writeable"
+        "writeable": "hydra:writeable",
+        "xsd": "https://www.w3.org/TR/xmlschema-2/#"
     },
     "@id": "http://localhost:8080/creditrisk_api/vocab",
     "@type": "ApiDocumentation",
@@ -65,105 +66,20 @@
     "possibleStatus": [],
     "supportedClass": [
         {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
             "@type": "hydra:Class",
-            "description": "Collateral Class",
-            "supportedOperation": [
-                {
-                    "@type": "http://schema.org/FindAction",
-                    "expects": null,
-                    "expectsHeader": [],
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Collateral class returned.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                    "returnsHeader": [],
-                    "title": "CollateralGET"
-                },
-                {
-                    "@type": "http://schema.org/AddAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                    "expectsHeader": [],
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Collateral class Added.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "CollateralPUT"
-                },
-                {
-                    "@type": "http://schema.org/UpdateAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                    "expectsHeader": [],
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Collateral class updated.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [
-                        "Content-Type",
-                        "Content-Length"
-                    ],
-                    "title": "CollateralPOST"
-                },
-                {
-                    "@type": "http://schema.org/DeleteAction",
-                    "expects": null,
-                    "expectsHeader": [],
-                    "method": "DELETE",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Collateral class Deleted.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "CollateralDELETE"
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
-                    "readable": true,
-                    "required": true,
-                    "title": "collateral_concerns_loan",
-                    "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_latest_valuation_amount",
-                    "readable": true,
-                    "required": true,
-                    "title": "has_latest_valuation_amount",
-                    "writeable": true
-                }
-            ],
-            "title": "Collateral"
+            "description": "General Counterparty Class (not necessarily to a credit contract)",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "GeneralCounterparty"
+        },
+        {
+            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCollateral",
+            "@type": "hydra:Class",
+            "description": "General Collateral Class",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "GeneralCollateral"
         },
         {
             "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Loan",
@@ -177,7 +93,7 @@
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Loan class returned.",
                             "statusCode": 200,
@@ -195,7 +111,7 @@
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Loan class Added.",
                             "statusCode": 200,
@@ -213,7 +129,7 @@
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Loan class updated.",
                             "statusCode": 200,
@@ -234,7 +150,7 @@
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Loan class Deleted.",
                             "statusCode": 200,
@@ -249,7 +165,7 @@
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "property": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "readable": true,
                     "required": true,
                     "title": "CounterpartyId",
@@ -258,130 +174,14 @@
                 {
                     "@type": "SupportedProperty",
                     "property": "https://www.openriskmanual.org/ns/nplo.owl#has_total_balance",
+                    "range": "xsd:float",
                     "readable": true,
                     "required": true,
                     "title": "has_total_balance",
                     "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_channel_of_origination",
-                    "readable": true,
-                    "required": true,
-                    "title": "has_channel_of_origination",
-                    "writeable": true
                 }
             ],
             "title": "Loan"
-        },
-        {
-            "@id": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-            "@type": "hydra:Class",
-            "description": "Counterparty Class (not necessarily to a credit contract)",
-            "supportedOperation": [
-                {
-                    "@type": "http://schema.org/FindAction",
-                    "expects": null,
-                    "expectsHeader": [],
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Counterparty class returned.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                    "returnsHeader": [],
-                    "title": "CounterpartyGET"
-                },
-                {
-                    "@type": "http://schema.org/AddAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                    "expectsHeader": [],
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Counterparty class Added.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "CounterpartyPUT"
-                },
-                {
-                    "@type": "http://schema.org/UpdateAction",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                    "expectsHeader": [],
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Counterparty class updated.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [
-                        "Content-Type",
-                        "Content-Length"
-                    ],
-                    "title": "CounterpartyPOST"
-                },
-                {
-                    "@type": "http://schema.org/DeleteAction",
-                    "expects": null,
-                    "expectsHeader": [],
-                    "method": "DELETE",
-                    "possibleStatus": [
-                        {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                            "@type": "Status",
-                            "description": "Counterparty class Deleted.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": null,
-                    "returnsHeader": [],
-                    "title": "CounterpartyDELETE"
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_total_assets",
-                    "readable": true,
-                    "required": true,
-                    "title": "has_total_assets",
-                    "writeable": true
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "https://www.openriskmanual.org/ns/nplo.owl#has_legal_entity_identifier",
-                    "readable": true,
-                    "required": true,
-                    "title": "has_legal_entity_identifier",
-                    "writeable": true
-                }
-            ],
-            "title": "Counterparty"
-        },
-        {
-            "@id": "http://www.w3.org/ns/hydra/core#Resource",
-            "@type": "hydra:Class",
-            "description": null,
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "Resource"
         },
         {
             "@id": "http://www.w3.org/ns/hydra/core#Collection",
@@ -405,7 +205,7 @@
             "@type": "Collection",
             "description": "Collection for Borrower class",
             "manages": {
-                "object": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                "object": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                 "property": "rdf:type"
             },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
@@ -418,64 +218,64 @@
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:CounterParty_collection_create",
                     "@type": "http://schema.org/AddAction",
                     "description": "Create new member in CounterParty_collection",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "A new member in CounterParty_collection created",
                             "statusCode": 201,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:CounterParty_collection_update",
                     "@type": "http://schema.org/UpdateAction",
                     "description": "Update member of  CounterParty_collection ",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If the entity was updatedfrom CounterParty_collection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:CounterParty_collection_delete",
                     "@type": "http://schema.org/DeleteAction",
                     "description": "Delete member of CounterParty_collection ",
-                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "expects": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "expectsHeader": [],
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If entity was deletedsuccessfully from CounterParty_collection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                    "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                     "returnsHeader": []
                 }
             ],
@@ -511,100 +311,160 @@
             ],
             "supportedProperty": [
                 {
-                    "hydra:description": "The Collateral Class",
-                    "hydra:title": "collateral",
+                    "hydra:description": "The Receiver Class",
+                    "hydra:title": "receiver",
                     "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Collateral",
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Receiver",
                         "@type": "hydra:Link",
-                        "description": "Collateral Class",
+                        "description": "Receiver Class",
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "Collateral",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                        "supportedOperation": [
-                            {
-                                "@id": "collateralget",
-                                "@type": "http://schema.org/FindAction",
-                                "description": null,
-                                "expects": null,
-                                "expectsHeader": [],
-                                "label": "CollateralGET",
-                                "method": "GET",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Collateral class returned.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "collateralput",
-                                "@type": "http://schema.org/AddAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                                "expectsHeader": [],
-                                "label": "CollateralPUT",
-                                "method": "PUT",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Collateral class Added.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "collateralpost",
-                                "@type": "http://schema.org/UpdateAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Collateral",
-                                "expectsHeader": [],
-                                "label": "CollateralPOST",
-                                "method": "POST",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Collateral class updated.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": [
-                                    "Content-Type",
-                                    "Content-Length"
-                                ]
-                            },
-                            {
-                                "@id": "collateraldelete",
-                                "@type": "http://schema.org/DeleteAction",
-                                "description": null,
-                                "expects": null,
-                                "expectsHeader": [],
-                                "label": "CollateralDELETE",
-                                "method": "DELETE",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Collateral class Deleted.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            }
-                        ]
+                        "label": "Receiver",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Receiver",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The GeneralCounterparty Class",
+                    "hydra:title": "generalcounterparty",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/GeneralCounterparty",
+                        "@type": "hydra:Link",
+                        "description": "General Counterparty Class (not necessarily to a credit contract)",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "GeneralCounterparty",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The CorporateBorrower Class",
+                    "hydra:title": "corporateborrower",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CorporateBorrower",
+                        "@type": "hydra:Link",
+                        "description": "Corporate Borrower Class. A sub-class of Borrower that applies to Corporations",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "CorporateBorrower",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CorporateBorrower",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The PersonalLoan Class",
+                    "hydra:title": "personalloan",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/PersonalLoan",
+                        "@type": "hydra:Link",
+                        "description": "Personal Loan class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "PersonalLoan",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=PersonalLoan",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The CorporateLoan Class",
+                    "hydra:title": "corporateloan",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CorporateLoan",
+                        "@type": "hydra:Link",
+                        "description": "Corporate Loan class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "CorporateLoan",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CorporateLoan",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The GeneralCollateral Class",
+                    "hydra:title": "generalcollateral",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/GeneralCollateral",
+                        "@type": "hydra:Link",
+                        "description": "General Collateral Class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "GeneralCollateral",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCollateral",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The CreditRatingAgency Class",
+                    "hydra:title": "creditratingagency",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/CreditRatingAgency",
+                        "@type": "hydra:Link",
+                        "description": "Credit Rating Agency Class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "CreditRatingAgency",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=CreditRatingAgency",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The Borrower Class",
+                    "hydra:title": "borrower",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Borrower",
+                        "@type": "hydra:Link",
+                        "description": "Borrower Class. A sub-class of Counterparty that applies to Lending relations",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "Borrower",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Borrower",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The InsolvencyPractitioner Class",
+                    "hydra:title": "insolvencypractitioner",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/InsolvencyPractitioner",
+                        "@type": "hydra:Link",
+                        "description": "Insolvency Practitioner Class",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "InsolvencyPractitioner",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=InsolvencyPractitioner",
+                        "supportedOperation": []
+                    },
+                    "readable": true,
+                    "required": null,
+                    "writeable": false
+                },
+                {
+                    "hydra:description": "The IndividualBorrower Class",
+                    "hydra:title": "individualborrower",
+                    "property": {
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/IndividualBorrower",
+                        "@type": "hydra:Link",
+                        "description": "Individual Borrower Class. A sub-class of Borrower that applies to Individuals",
+                        "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
+                        "label": "IndividualBorrower",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=IndividualBorrower",
+                        "supportedOperation": []
                     },
                     "readable": true,
                     "required": null,
@@ -631,7 +491,7 @@
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Loan class returned.",
                                         "statusCode": 200,
@@ -651,7 +511,7 @@
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Loan class Added.",
                                         "statusCode": 200,
@@ -671,7 +531,7 @@
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Loan class updated.",
                                         "statusCode": 200,
@@ -694,7 +554,7 @@
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Loan class Deleted.",
                                         "statusCode": 200,
@@ -711,100 +571,16 @@
                     "writeable": false
                 },
                 {
-                    "hydra:description": "The Counterparty Class",
-                    "hydra:title": "counterparty",
+                    "hydra:description": "The InsuranceProvider Class",
+                    "hydra:title": "insuranceprovider",
                     "property": {
-                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/Counterparty",
+                        "@id": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint/InsuranceProvider",
                         "@type": "hydra:Link",
-                        "description": "Counterparty Class (not necessarily to a credit contract)",
+                        "description": "Insurance Provider Class",
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
-                        "label": "Counterparty",
-                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                        "supportedOperation": [
-                            {
-                                "@id": "counterpartyget",
-                                "@type": "http://schema.org/FindAction",
-                                "description": null,
-                                "expects": null,
-                                "expectsHeader": [],
-                                "label": "CounterpartyGET",
-                                "method": "GET",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Counterparty class returned.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "counterpartyput",
-                                "@type": "http://schema.org/AddAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                                "expectsHeader": [],
-                                "label": "CounterpartyPUT",
-                                "method": "PUT",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Counterparty class Added.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "counterpartypost",
-                                "@type": "http://schema.org/UpdateAction",
-                                "description": null,
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
-                                "expectsHeader": [],
-                                "label": "CounterpartyPOST",
-                                "method": "POST",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Counterparty class updated.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": [
-                                    "Content-Type",
-                                    "Content-Length"
-                                ]
-                            },
-                            {
-                                "@id": "counterpartydelete",
-                                "@type": "http://schema.org/DeleteAction",
-                                "description": null,
-                                "expects": null,
-                                "expectsHeader": [],
-                                "label": "CounterpartyDELETE",
-                                "method": "DELETE",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
-                                        "@type": "Status",
-                                        "description": "Counterparty class Deleted.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": null,
-                                "returnsHeader": []
-                            }
-                        ]
+                        "label": "InsuranceProvider",
+                        "range": "http://localhost:8080/creditrisk_api/vocab?resource=InsuranceProvider",
+                        "supportedOperation": []
                     },
                     "readable": true,
                     "required": null,
@@ -820,7 +596,7 @@
                         "domain": "http://localhost:8080/creditrisk_api/vocab?resource=EntryPoint",
                         "label": "CounterParty_collection",
                         "manages": {
-                            "object": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                            "object": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                             "property": "rdf:type"
                         },
                         "range": "http://localhost:8080/creditrisk_api/vocab?resource=CounterParty_collection",
@@ -833,64 +609,64 @@
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:counterparty_collection_create",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "Create new member in CounterParty_collection",
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "A new member in CounterParty_collection created",
                                         "statusCode": 201,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:counterparty_collection_update",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "Update member of  CounterParty_collection ",
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "expectsHeader": [],
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If the entity was updatedfrom CounterParty_collection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:counterparty_collection_delete",
                                 "@type": "http://schema.org/DeleteAction",
                                 "description": "Delete member of CounterParty_collection ",
-                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "expects": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "expectsHeader": [],
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If entity was deletedsuccessfully from CounterParty_collection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=Counterparty",
+                                "returns": "http://localhost:8080/creditrisk_api/vocab?resource=GeneralCounterparty",
                                 "returnsHeader": []
                             }
                         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,19 @@ def get_doc_classes_and_properties(doc):
     return test_classes, test_properties
 
 
+def get_doc_classes_and_properties(doc):
+    """
+    Extract classes and properties from a given HydraDoc object
+    :param doc: HydraDoc object whose classes and properties have to extracted
+    :type doc: HydraDoc
+    :return: classes and properties in the HydraDoc object in a tuple
+    :rtype: tuple(list, set)
+    """
+    test_classes = doc_parse.get_classes(doc)
+    test_properties = doc_parse.get_all_properties(test_classes)
+    return (test_classes, test_properties)
+
+
 def gen_dummy_object(class_title, doc):
     """
     Create a dummy object based on the definitions in the API Doc.
@@ -80,9 +93,14 @@ def gen_dummy_object(class_title, doc):
                     prop_class = prop.prop.split(expanded_base_url)[1]
                     object_[prop.title] = gen_dummy_object(prop_class, doc)
                 else:
-                    object_[prop.title] = ''.join(random.choice(
-                        string.ascii_uppercase + string.digits) for _ in range(6))
+                    type_ = prop.kwargs.get('range')
+                    if type_ is not None:
+                        object_[prop.title] = random.randint(50,100)
+                    else:
+                        object_[prop.title] = ''.join(random.choice(
+                            string.ascii_uppercase + string.digits) for _ in range(6))
             return object_
+
 
 @pytest.fixture(scope='module')
 def constants():

--- a/tests/mock_portfolio_generator.py
+++ b/tests/mock_portfolio_generator.py
@@ -25,7 +25,7 @@ def borrowers_with_no_loan(apidoc: HydraDoc):
     """
     for borrower in range(100):
         dummy_object = gen_dummy_object("Counterparty", apidoc)
-        put_request = requests.put("http://localhost:8080/creditrisk_api/Counterparty/", json=dummy_object)
+        put_request = requests.put("http://localhost:8080/creditrisk_api/GeneralCounterparty/", json=dummy_object)
 
 
 def borrower_with_loan(apidoc: HydraDoc):
@@ -34,7 +34,7 @@ def borrower_with_loan(apidoc: HydraDoc):
     """
     for borrower in range(100):
         # Creating Counterparty Object
-        counterparty_dummy_object = gen_dummy_object("Counterparty", apidoc)
+        counterparty_dummy_object = gen_dummy_object("GeneralCounterparty", apidoc)
         # Loan object using CounterpartyId
         loan_dummy_object = gen_dummy_object("Loan", apidoc)
         loan_dummy_object['CounterpartyId'] = counterparty_dummy_object
@@ -54,11 +54,11 @@ def borrower_with_loan_and_collateral(apidoc: HydraDoc):
         # Creating Collateral dummy object using ConcernLoan
         collateral_dummy_object = gen_dummy_object("Collateral", apidoc)
         collateral_dummy_object['collateral_concerns_loan'] = loan_dummy_object
-        put_request = requests.put("http://localhost:8080/creditrisk_api/Collateral", json=collateral_dummy_object)
+        put_request = requests.put("http://localhost:8080/creditrisk_api/GeneralCollateral", json=collateral_dummy_object)
 
 
 if __name__ == "__main__":
     doc = get_api_doc()
     #borrowers_with_no_loan(doc)
-    #borrower_with_loan(doc)
-    borrower_with_loan_and_collateral(doc)
+    borrower_with_loan(doc)
+    #borrower_with_loan_and_collateral(doc)


### PR DESCRIPTION
I have implemented the feature released with `hydrus==0.4.4`.
Now the data columns are being generated according to the property type (`xsd:range`).

I have simplified the ApiDoc and here is the DB schema

![Screenshot from 2021-07-09 18-47-53](https://user-images.githubusercontent.com/49719371/125087361-0c675600-e0ea-11eb-802f-331a0748d82c.png)

`has_total_balace` property column generated is of `Float` type.

`gen_dummy_object` function is also working fine ( generating column acc. to property type)

![Screenshot from 2021-07-09 18-48-06](https://user-images.githubusercontent.com/49719371/125087547-328cf600-e0ea-11eb-8eff-40b30b2c7004.png)

Tests are updated according to the changes in `hydrus==0.4.4`

All the tests are passing using the ApiDoc generated by automation after making all the changes.

![Screenshot from 2021-07-09 18-49-10](https://user-images.githubusercontent.com/49719371/125087883-81d32680-e0ea-11eb-9e69-77db5df1d56c.png)
