### PR TITLE
remove apidoc path environment variable from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - DEBUG=1
       - API_NAME=creditrisk_api
-      - APIDOC_REL_PATH=creditrisk_poc/api_doc/ApiDoc.jsonld
+      # - APIDOC_REL_PATH=creditrisk_poc/api_doc/ApiDoc.jsonld
       - DB_URL=postgresql://creditrisk:creditriskpass@pg_main:5432/testdb
       - PORT=8080
     depends_on:


### PR DESCRIPTION
If we'll provide a env variable for APIDOC path, there's a line in creditrisk's main.py :
`from hydrus.extensions.socketio_factory import create_socket`

This will first try to create a APIDOC object in hydrus (which will look for apidoc path inside hydrus) and then it'll return that no such doc file is present at `hydrus/creditrisk_poc/api_doc/apidoc.jsonld` 

We can comment out the `APIDOC_REL_PATH` from docker-compose.yml for now.